### PR TITLE
遅いテストとパフォーマンステストにカテゴリ付与

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,57 @@
   </scm>
 
   <issueManagement>
-    <system>JIRA</system>
-    <url><![CDATA[https://www.seasar.org/issues/browse/MAYAA]]></url>
+    <system>Github</system>
+    <url>https://github.com/seasarorg/mayaa/issues</url>
   </issueManagement>
 
   <inceptionYear>2004</inceptionYear>
+
+  <properties>
+    <!-- 普段はJUnitパフォーマンス計測用テスト、遅いテストは除外する -->
+    <testExcludedGroups>test.PerformanceTest.class,test.SlowTest.class</testExcludedGroups>
+    <testArgLine></testArgLine>
+  </properties>
+
+  <profiles>
+    <profile>
+        <!-- JUnitにて低速なテストも含めて実行するためのプロファイル -->
+        <id>withSlowTest</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <excludedGroups>test.PerformanceTest.class</excludedGroups>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+        <properties>
+        </properties>
+      </profile>
+      <profile>
+        <!-- JUnitにてパフォーマンスの検証を行うためのプロファイル -->
+        <!-- 対象テストを test.PerformanceTest.class に限定し、Java Flight Recorder を有効にする -->
+        <id>withPerformanceTest</id>
+        <properties>
+          <testExcludedGroups></testExcludedGroups><!-- 除外テスト指定を空にする-->
+        </properties>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <groups>test.PerformanceTest.class</groups>
+                <argLine>-XX:+FlightRecorder -XX:StartFlightRecording=duration=60s,filename=target/performance-test.jfr</argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+  </profiles>
 
   <mailingLists>
     <mailingList>
@@ -150,12 +196,21 @@
             <encoding>UTF-8</encoding>
             <source>1.7</source>
             <target>1.7</target>
+            <compilerArgument>-Xlint:deprecation</compilerArgument>
           </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <configuration>
             <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <excludedGroups>${testExcludedGroups}</excludedGroups>
+            <argLine>${testArgLine}</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/src/test/java/org/seasar/mayaa/functional/EngineTestBase.java
+++ b/src/test/java/org/seasar/mayaa/functional/EngineTestBase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.seasar.mayaa.functional;
 
 import static org.junit.Assert.assertEquals;
@@ -71,7 +86,7 @@ public class EngineTestBase {
      * @param path 処理するHTMLファイルへのパス（クラスパスルートからのパス）
      * @return リクエストオブジェクト（モック）
      */
-    MockHttpServletRequest createRequest(final String path) {
+    protected MockHttpServletRequest createRequest(final String path) {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setServletPath(path);
         return request;
@@ -82,7 +97,7 @@ public class EngineTestBase {
      * 
      * @return ServletContextオブジェクト
      */
-    MockServletContext getServletContext() {
+    protected MockServletContext getServletContext() {
         return servletContext;
     }
 
@@ -93,7 +108,7 @@ public class EngineTestBase {
      * @param pageScopeAttribute あらかじめページスコープに定義済のものとして引き渡す属性のマップ
      * @return レスポンスオブジェクト（モック）
      */
-    MockHttpServletResponse exec(final MockHttpServletRequest request, final Map<String, Object> pageScopeAttribute) {
+    protected MockHttpServletResponse exec(final MockHttpServletRequest request, final Map<String, Object> pageScopeAttribute) {
         final MockHttpServletResponse response = new MockHttpServletResponse();
 
         CycleUtil.initialize(request, response);
@@ -110,7 +125,7 @@ public class EngineTestBase {
      * @param expectedContentPath 機体結果の内容が保管されているファイルへのパス（クラスパスルートからのパス）
      * @throws IOException IOエラーが発生した場合
      */
-    void verifyResponse(final MockHttpServletResponse response, final String expectedContentPath) throws IOException {
+    protected void verifyResponse(final MockHttpServletResponse response, final String expectedContentPath) throws IOException {
 
         final URL url = getClass().getResource(expectedContentPath);
         if (url == null) {
@@ -164,7 +179,7 @@ public class EngineTestBase {
      * @param expectedContentPath
      * @param pageScopeAttribute
      */
-    void execAndVerify(final String targetContentPath, final String expectedContentPath,
+    protected void execAndVerify(final String targetContentPath, final String expectedContentPath,
             final Map<String, Object> pageScopeAttribute) throws IOException {
         final MockHttpServletRequest request = createRequest(targetContentPath);
 

--- a/src/test/java/org/seasar/mayaa/impl/cycle/scope/StubApplicationScopeSupport.java
+++ b/src/test/java/org/seasar/mayaa/impl/cycle/scope/StubApplicationScopeSupport.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.seasar.mayaa.impl.cycle.scope;
 
 import java.io.InputStream;
@@ -164,22 +179,27 @@ public class StubApplicationScopeSupport extends AbstractWritableAttributeScope 
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public Servlet getServlet(String name) throws ServletException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public Enumeration getServlets() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public Enumeration getServletNames() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public void log(String msg) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     public void log(Exception exception, String msg) {
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/test/PerformanceTest.java
+++ b/src/test/java/test/PerformanceTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package test;
+
+public interface PerformanceTest {
+    
+}

--- a/src/test/java/test/SlowTest.java
+++ b/src/test/java/test/SlowTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package test;
+
+public interface SlowTest {
+    
+}


### PR DESCRIPTION
遅いテストを含めるとき `mvn test -PwithSlowTest`
パフォーマンステストの場合 `mvn test -PwithPerformanceTest`
パフォーマンステストはJFR有効としているためJDKは AdoptOpenJDK11 以降のみ。