### PR TITLE
WeakValueHashMapの再実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [#16](https://github.com/seasarorg/mayaa/issues/16) - Mayaa動作要件の最低JavaバージョンをJava7としました。
 
 ### Fixes
-- [#14](https://github.com/seasarorg/mayaa/issues/14) - 複数スレッド下でスクリプトキャッシュの競合が発生する場合があるのを修正しました。(予定)
+- [#14](https://github.com/seasarorg/mayaa/issues/14) - 複数スレッド下でスクリプトキャッシュの競合を解消するとともにキャッシュ保持数の制御を改善しました。
 
 ## Mayaa 1.1.34 : 2017-07-30
 ### Fixes

--- a/src-impl/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentImpl.java
@@ -48,17 +48,15 @@ import org.seasar.mayaa.source.SourceDescriptor;
  */
 public class ScriptEnvironmentImpl extends AbstractScriptEnvironment {
     private static final long serialVersionUID = -4067264733660357274L;
+    private static final int DEFAULT_HARD_SIZE = 128;
+
     private static Scriptable _standardObjects;
-    private static WeakValueHashMap/*<String, CompiledScript>*/ scriptCache;
+    private WeakValueHashMap<String, CompiledScript> scriptCache = new WeakValueHashMap<>(DEFAULT_HARD_SIZE);
 
     private static final boolean CONSTRAINT_GLOBAL_PROPERTY_DEFINE = true;
 
     // singleton
     private static WrapFactory _wrap;
-    private static int _cacheSize = 128;
-    static {
-        setScriptCacheSize(_cacheSize);
-    }
 
     private boolean _useGetterScriptEmulation;
 
@@ -252,13 +250,12 @@ public class ScriptEnvironmentImpl extends AbstractScriptEnvironment {
         return (scriptObject instanceof Scriptable);
     }
 
-    static void setScriptCacheSize(int cacheSize) {
-        _cacheSize = cacheSize;
-        scriptCache = new WeakValueHashMap(cacheSize);
+    public void setScriptCacheSize(int cacheSize) {
+        scriptCache.setHardSize(cacheSize);
     }
 
-    static int getScriptCacheSize() {
-        return _cacheSize;
+    public int getScriptCacheSize() {
+        return scriptCache.getHardSize();
     }
 
     static void setWrapFactory(WrapFactory wrap) {

--- a/src/test/java/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.seasar.mayaa.impl.cycle.script.rhino;
 
 import static org.junit.Assert.assertEquals;
@@ -29,10 +44,11 @@ public class ScriptEnvironmentTest {
         // ファクトリーを経由してScriptEnvironmentインスタンスを生成する
         ProviderFactory providerFactory = (ProviderFactory) FactoryFactory.getFactory(ProviderFactory.class);
         // ServiceProviderのインスタンスを取得することでScriptEnvironmentを作成する。
-        providerFactory.getServiceProvider();
+        ScriptEnvironmentImpl scriptEnvironmentImpl = (ScriptEnvironmentImpl) providerFactory.getServiceProvider()
+                .getScriptEnvironment();
 
         //-- Then
         // スクリプトのキャッシュ設定値が256に設定されている。
-        assertEquals(256, ScriptEnvironmentImpl.getScriptCacheSize());
+        assertEquals(256, scriptEnvironmentImpl.getScriptCacheSize());
     }
 }

--- a/src/test/java/org/seasar/mayaa/impl/util/WeakValueHashMapTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/util/WeakValueHashMapTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.impl.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class WeakValueHashMapTest {
+
+    @Test
+    public void 引数なしコンストラクタの場合はデフォルトサイズの128で作成される() {
+        WeakValueHashMap<String, String> testee = new WeakValueHashMap<>();
+
+        assertEquals(128, testee.getHardSize());
+    }
+
+    @Test
+    public void 指定したサイズを基準に強参照と弱参照が移動する() {
+        WeakValueHashMap<String, String> testee = new WeakValueHashMap<>(2);
+
+        testee.put("key1", "val1");
+        testee.put("key2", "val2");
+        assertEquals(0, testee.getDroppedCount());
+        assertEquals(0, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key3 を追加することで key1 が弱参照になる（ドロップする）。
+        // key1は参照されていないため getMaxCountOfDroppedRecord()は0のまま。
+        testee.put("key3", "val3");
+        assertEquals(1, testee.getDroppedCount());
+        assertEquals(0, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key3 は現在は強参照のため参照してもDroppedカウントもPullUpカウントは上がらない。
+        assertEquals("val3", testee.get("key3"));
+        assertEquals(1, testee.getDroppedCount());
+        assertEquals(0, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key4 を追加することで key2 が弱参照になる
+        testee.put("key4", "val4");
+        assertEquals(2, testee.getDroppedCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key3 はまだ強参照のため参照してもDroppedカウントもPullUpカウントは上がらない。
+        assertEquals(testee.get("key3"), "val3");
+        assertEquals(2, testee.getDroppedCount());
+        assertEquals(0, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key1 は弱参照から取得されるため key3 がドロップし、key1がプルアップされる。
+        assertEquals("val1", testee.get("key1"));
+        assertEquals(3, testee.getDroppedCount());
+        assertEquals(1, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key1 は現在は強参照のため参照してもDroppedカウントもPullUpカウントは上がらない。
+        assertEquals("val1", testee.get("key1"));
+        assertEquals(3, testee.getDroppedCount());
+        assertEquals(1, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        // key2 は弱参照から取得されるため key3 がドロップし、key2がプルアップされる。
+        // key3は2回参照されたため getMaxCountOfDroppedRecord() が2を返却する。
+        assertEquals("val2", testee.get("key2"));
+        assertEquals(4, testee.getDroppedCount());
+        assertEquals(2, testee.getPullUpCount());
+        assertEquals(2, testee.getMaxCountOfDroppedRecord());
+
+        assertEquals("val4", testee.get("key4"));
+        assertEquals(5, testee.getDroppedCount());
+        assertEquals(3, testee.getPullUpCount());
+        assertEquals(2, testee.getMaxCountOfDroppedRecord());
+    }
+
+    @Test
+    public void 弱参照のレコードが削除される() throws InterruptedException {
+        WeakValueHashMap<String, String> testee = new WeakValueHashMap<>(2);
+
+
+        testee.put("key1", new String("val1"));
+        assertEquals(1, testee.size());
+
+        testee.put("key2", new String("val2"));
+        assertEquals(2, testee.size());
+
+        for (int i = 3; i < 10; ++i) {
+            testee.put("key" + i, new String("val" + i));
+            assertEquals(i, testee.size());
+        }
+
+        System.gc();
+        Thread.sleep(2); // GCのスレッドに処理を明け渡して完了を少し待つ
+
+        assertEquals(2, testee.size());
+    }
+
+    @Test
+    public void 指定したサイズを変更しても追従する() {
+        WeakValueHashMap<String, String> testee = new WeakValueHashMap<>(2);
+
+        assertEquals(2, testee.getHardSize());
+
+        testee.put("key1", "val1");
+        testee.put("key2", "val2");
+        testee.put("key3", "val3");
+        testee.put("key4", "val4");
+
+        assertEquals(2, testee.getDroppedCount());
+        assertEquals(0, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        testee.setHardSize(3);
+
+        testee.put("key1", "val1");
+        assertEquals(2, testee.getDroppedCount()); // ドロップしない
+        assertEquals(1, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        testee.put("key2", "val2");
+        assertEquals(3, testee.getDroppedCount()); // key3がドロップする
+        assertEquals(2, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+        testee.setHardSize(2);
+
+        // 減らした時点でkey4がドロップする
+        assertEquals(4, testee.getDroppedCount());
+
+        // key1はまだ強参照のままなのでドロップしない
+        testee.get("key1");
+        assertEquals(4, testee.getDroppedCount());
+
+        // key3は弱参照からプルアップされ、key2がドロップする
+        testee.get("key3");
+        assertEquals(5, testee.getDroppedCount());
+        assertEquals(3, testee.getPullUpCount());
+        assertEquals(0, testee.getMaxCountOfDroppedRecord());
+
+    }
+
+}
+

--- a/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.groovy
+++ b/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.groovy
@@ -1,0 +1,58 @@
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+
+final cacheSize = 128  // Mayaaの実装と同じ
+final threadsCount = 200
+final trialCount = 100
+def lock = new Object()
+def foundNSEE = new AtomicBoolean(false)
+def l = new LinkedList()
+
+for (int trialId = 0; trialId < trialCount && !foundNSEE.get(); trialId++) {
+    def latch = new CountDownLatch(threadsCount)
+    threads = (1..threadsCount).collect { requestId ->
+        def id = "[$trialId]$requestId"
+        Thread.start {
+            try {
+                // 一斉に動いた方がぶつかりやすいので待ち合わせる
+                latch.countDown()
+                latch.await()
+
+                synchronized (lock) {
+                    l.addFirst("ITEM:$id") // addFirstは同期的にしか実行されないため、同じように同期化する
+                }
+                if (l.size() > cacheSize) {
+                    l.removeLast() // これが複数同時に実行された場合、が問題
+                }
+            } catch (NoSuchElementException e) {
+                println id
+                e.printStackTrace()
+                foundNSEE.set(true)
+            }
+        }
+    }
+    threads*.join()
+}
+
+if (!foundNSEE.get()) {
+    println "Not reproduced (no error)."
+    System.exit(0)
+}
+
+// (厳密には壊れ方にもよるが)1回でも発生すると、あとはなんどやってもエラーになる(場合がある)
+def verifyTrialCount = 100
+def nseeCount = 0
+verifyTrialCount.times {
+    l.addFirst("DUMMY")
+    assert l.size() > 0
+    try {
+        l.removeLast()
+    } catch (NoSuchElementException e) {
+        nseeCount++
+    }
+}
+if (nseeCount == verifyTrialCount) {
+    println "Reproduced!"
+} else {
+    println "Not reproduced (error occurs but it works later)."
+}

--- a/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.java
+++ b/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.java
@@ -1,0 +1,91 @@
+package org.seasar.mayaa.regressions.issue14;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.seasar.mayaa.impl.util.WeakValueHashMap;
+
+import junit.framework.TestCase;
+
+/**
+ * https://github.com/seasarorg/mayaa/issues/14 を元に {@code WeakValueHashMap} で {@link NoSuchElementException} が
+ * 発生する問題の再現を確認するコードとしてJavaに焼き直したもの。
+ * 再現するとJUnitとして失敗する。
+ */
+public class Issue14ReproductionTest extends TestCase {
+
+    static final int cacheSize = 128; // Mayaaの実装と同じ
+
+    static final AtomicBoolean foundNSEE = new AtomicBoolean(false);
+    static final WeakValueHashMap l = new WeakValueHashMap(cacheSize);
+
+    public static void main(final String[] args) throws InterruptedException {
+        final Issue14ReproductionTest testee = new Issue14ReproductionTest();
+        testee.testReproduceTrial();
+    }
+
+    /**
+     * repdocudeMainを何回か試行して再現確認を行う。
+     */
+    public void testReproduceTrial() throws InterruptedException {
+        final int THREAD_COUNT = 10;
+        final int TRIAL_COUNT = 200;
+
+        for (int trialId = 0; trialId < TRIAL_COUNT && !foundNSEE.get(); trialId++) {
+            if (reproduceMain(trialId, THREAD_COUNT)) {
+                fail("Reproduced! Trial:" + trialId);
+            }
+        }
+    }
+
+
+    /**
+     * NoSuchElementExceptioの再現の主処理。
+     * 複数のスレッドで同時に WeakValueHashMapを参照する。
+     * 
+     * @param trialId 試行番号
+     * @param threadsCount 同時実行するスレッド数
+     * @return NoSuchElementExceptionが発生したら(再現したら) true
+     * @throws InterruptedException スレッド待ち合わせ処理が中断した場合
+     */
+    boolean reproduceMain(final int trialId, final int threadsCount) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(threadsCount);
+
+        Thread[] threads = new Thread[threadsCount];
+        for (int requestId = 0; requestId < threadsCount; requestId++) {
+            final String id = "[" + trialId + "]" + requestId;
+
+            threads[requestId] = new Thread() {
+                public void run() {
+                    try {
+                        String key = "ITEM:" + id;
+
+                        // 一斉に動いた方がぶつかりやすいので待ち合わせる
+                        latch.countDown();
+                        latch.await();
+
+                        l.put(key, id);
+                        l.get(key);
+                    } catch (final NoSuchElementException e) {
+                        e.printStackTrace(System.err);
+                        foundNSEE.set(true);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            threads[requestId].start();
+        }
+
+        // スレッドの終了を待ち合わせる
+        for (int requestId = 0; requestId < threadsCount; requestId++) {
+            threads[requestId].join();
+        }
+
+        //　結果の判定
+        return foundNSEE.get();
+    }
+
+
+}

--- a/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.java
+++ b/src/test/java/org/seasar/mayaa/regressions/issue14/Issue14ReproductionTest.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.seasar.mayaa.regressions.issue14;
 
 import java.util.NoSuchElementException;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.Test;
 import org.seasar.mayaa.impl.util.WeakValueHashMap;
 
 import junit.framework.TestCase;
@@ -15,10 +32,10 @@ import junit.framework.TestCase;
  */
 public class Issue14ReproductionTest extends TestCase {
 
-    static final int cacheSize = 128; // Mayaaの実装と同じ
+    static final int cacheSize = 3; // Mayaaの実装と同じ
 
     static final AtomicBoolean foundNSEE = new AtomicBoolean(false);
-    static final WeakValueHashMap l = new WeakValueHashMap(cacheSize);
+    static final WeakValueHashMap<String, String> l = new WeakValueHashMap<>(cacheSize);
 
     public static void main(final String[] args) throws InterruptedException {
         final Issue14ReproductionTest testee = new Issue14ReproductionTest();
@@ -28,9 +45,10 @@ public class Issue14ReproductionTest extends TestCase {
     /**
      * repdocudeMainを何回か試行して再現確認を行う。
      */
+    @Test
     public void testReproduceTrial() throws InterruptedException {
-        final int THREAD_COUNT = 10;
-        final int TRIAL_COUNT = 200;
+        final int THREAD_COUNT = 20;
+        final int TRIAL_COUNT = 1000;
 
         for (int trialId = 0; trialId < TRIAL_COUNT && !foundNSEE.get(); trialId++) {
             if (reproduceMain(trialId, THREAD_COUNT)) {
@@ -52,9 +70,18 @@ public class Issue14ReproductionTest extends TestCase {
     boolean reproduceMain(final int trialId, final int threadsCount) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(threadsCount);
 
+        Random random = new Random(trialId);
+
         Thread[] threads = new Thread[threadsCount];
         for (int requestId = 0; requestId < threadsCount; requestId++) {
-            final String id = "[" + trialId + "]" + requestId;
+            final String id = "" + random.nextInt(10);
+            if (random.nextInt(100) == 0) {
+                System.gc();
+                // System.out.println("gc---------");
+            }
+            // if (requestId % 100 == 0) {
+            //     System.out.println(l.getMaxCountOfDroppedRecord());
+            // }
 
             threads[requestId] = new Thread() {
                 public void run() {


### PR DESCRIPTION
WeakValueHashMapは値を弱参照として保持することでScriptEnvironmentImpl内でキャッシュとして利用されているが、いくつかの課題がある。

1. #14 で指摘されているように同期化が完全には実施できていない
2. 直近で参照された値を固定枠で（デフォルトは128個）を強参照として保持させるようにしているが、同じ値を何度も参照した場合でもこの枠を消費してしまうため、複数のスクリプトが高頻度で参照されている場合のキャッシュヒット率が高くならない。枠の意味があまりないように見受けられる。

したがって、LRUで固定個数を保持しながら、LRUで吐き出されたものを弱参照で保持するように再実装した。
新実装ではWeakValueHashMap単体で同期化処理を行うようにしている。
また、強参照で保持させる個数は実行中に変更できるようにしている。
（運用中にメモリ問題が発生した場合に外部から縮小させるようにしておく）
