### PR TITLE
スクリプト実行のテストを追加

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,17 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src-api"/>
-	<classpathentry kind="src" path="src-impl"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/nekohtml-0.9.5.jar" sourcepath="srczip/nekohtml-src-0.9.5.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/xercesImpl-2.7.1.jar" sourcepath="srczip/Xerces-J-src.2.7.1.zip"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib-servlet/jsp-2.0.jar" sourcepath="srczip/jsp-src-2.0.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib-servlet/servlet-2.4.jar" sourcepath="srczip/servlet-src-2.3.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/commons-collections-3.1.jar" sourcepath="srczip/commons-collections-src-3.1.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/xml-apis-1.3.03.jar"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/commons-logging-1.0.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/jaxen-1.1.1.jar" sourcepath="srczip/jaxen-src-1.1.1.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/rhino-1.7r2.jar" sourcepath="srczip/rhino-src-1.7r2.zip"/>
-	<classpathentry exported="true" kind="lib" path="context/WEB-INF/lib/commons-beanutils-core-1.8.3.jar" sourcepath="srczip/commons-beanutils-src-1.8.3.zip"/>
-	<classpathentry kind="output" path="context/WEB-INF/classes"/>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src-api">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src-impl">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="context/resource">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>com.sysdeo.eclipse.tomcat.tomcatnature</nature>
 	</natures>

--- a/src/test/java/org/seasar/mayaa/functional/EngineTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/EngineTest.java
@@ -37,4 +37,11 @@ public class EngineTest extends EngineTestBase {
         execAndVerify("/it-case/html-transform/charset-html5/target.html", "/it-case/html-transform/charset-html5/expected.html", null);
     }
 
+
+    @Test
+    public void スクリプト実行_Javaクラス参照() throws IOException {
+        System.setProperty("test.value", "TEST VALUE");
+        execAndVerify("/it-case/script/java-bridge/target.html", "/it-case/script/java-bridge/expected.html", null);
+    }
+
 }

--- a/src/test/java/org/seasar/mayaa/impl/cycle/script/rhino/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
+++ b/src/test/java/org/seasar/mayaa/impl/cycle/script/rhino/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
@@ -4,13 +4,158 @@
     "http://mayaa.seasar.org/dtd/mayaa-provider_1_0.dtd">
 <provider class="org.seasar.mayaa.impl.provider.ServiceProviderImpl">
 
+    <engine class="org.seasar.mayaa.impl.engine.EngineImpl">
+        <errorHandler class="org.seasar.mayaa.impl.engine.error.TemplateErrorHandler">
+            <parameter name="folder" value="/"/>
+            <parameter name="extension" value="html"/>
+        </errorHandler>
+        <parameter name="pageClass" value="org.seasar.mayaa.impl.engine.PageImpl"/>
+        <parameter name="templateClass" value="org.seasar.mayaa.impl.engine.TemplateImpl"/>
+        <parameter name="defaultSpecification" value="/default.mayaa"/>
+        <parameter name="checkTimestamp" value="true"/>
+        <parameter name="suffixSeparator" value="$"/>
+        <parameter name="requestedSuffixEnabled" value="false" />
+        <parameter name="welcomeFileName" value="index.html"/>
+        <parameter name="requestCharacterEncoding" value="UTF-8"/>
+        <parameter name="pageSerialize" value="false"/>
+        <parameter name="surviveLimit" value="5"/>
+        <parameter name="autoBuild" value="false"/>
+        <parameter name="autoBuild.repeat" value="false"/>
+        <parameter name="autoBuild.wait" value="60"/><!-- seconds -->
+        <parameter name="autoBuild.fileNameFilters" value=".html"/><!-- .html;^(sample|howto).+\.htm$ -->
+        <parameter name="autoBuild.renderMate" value="false"/>
+        <parameter name="autoBuild.contextPath" value="/"/>
+        <parameter name="forwardLimit" value="10"/>
+        <parameter name="noCacheValue" value="no-cache"/><!-- since 1.1.27, for firefox "no-cache, no-store" -->
+        <parameter name="dumpEnabled" value="false" />
+        <parameter name="convertCharset" value="false"/><!-- since 1.1.12 -->
+    </engine>
+
     <scriptEnvironment class="org.seasar.mayaa.impl.cycle.script.rhino.ScriptEnvironmentImpl">
         <scope class="org.seasar.mayaa.impl.cycle.scope.ParamScope"/>
         <scope class="org.seasar.mayaa.impl.cycle.scope.HeaderScope"/>
         <scope class="org.seasar.mayaa.impl.cycle.scope.BindingScope"/>
 
+        <!-- "_" = current - page - request - session - application -->
+        <scope class="org.seasar.mayaa.impl.cycle.script.rhino.WalkStandardScope"/>
+        <!-- extension: java.lang.System.getProperty()
+        <scope class="org.seasar.mayaa.impl.cycle.scope.EnvScope"/>
+        -->
         <parameter name="wrapFactory" value="org.seasar.mayaa.impl.cycle.script.rhino.WrapFactoryImpl"/>
         <parameter name="cacheSize" value="256"/><!-- since 1.1.35-SNAPSHOT -->
     </scriptEnvironment>
+
+    <specificationBuilder class="org.seasar.mayaa.impl.builder.SpecificationBuilderImpl">
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="outputMayaaWhitespace" value="false"/>
+    </specificationBuilder>
+
+    <libraryManager class="org.seasar.mayaa.impl.builder.library.LibraryManagerImpl">
+        <converter name="ProcessorProperty" class="org.seasar.mayaa.impl.builder.library.converter.ProcessorPropertyConverter"/>
+        <converter name="PrefixAwareName" class="org.seasar.mayaa.impl.builder.library.converter.PrefixAwareNameConverter"/>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.FolderSourceScanner">
+            <parameter name="folder" value="/WEB-INF"/>
+            <parameter name="recursive" value="true"/>
+            <parameter name="extension" value=".tld"/>
+            <parameter name="extension" value=".mld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.MetaInfSourceScanner">
+            <parameter name="folder" value="/WEB-INF/lib"/>
+            <parameter name="extension" value=".jar"/>
+            <parameter name="ignore" value="commons-beanutils-"/>
+            <parameter name="ignore" value="commons-collections-"/>
+            <parameter name="ignore" value="commons-logging-"/>
+            <parameter name="ignore" value="nekohtml-"/>
+            <parameter name="ignore" value="jaxen-"/>
+            <parameter name="ignore" value="xml-apis-"/>
+            <parameter name="ignore" value="xercesImpl-"/>
+            <parameter name="ignore" value="rhino-"/>
+            <parameter name="jar.ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="jar.extension" value=".mld"/>
+            <parameter name="jar.extension" value=".tld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.ResourceScanner">
+            <parameter name="root" value="META-INF/"/>
+            <parameter name="ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="extension" value=".mld"/>
+            <parameter name="extension" value=".tld"/>
+        </scanner>
+
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.DefaultSourceScanner"/>
+
+        <!-- after scan jars -->
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.WebXMLTaglibSourceScanner"/>
+
+        <builder class="org.seasar.mayaa.impl.builder.library.MLDDefinitionBuilder"/>
+        <builder class="org.seasar.mayaa.impl.builder.library.TLDDefinitionBuilder"/>
+    </libraryManager>
+
+    <templateBuilder class="org.seasar.mayaa.impl.builder.TemplateBuilderImpl">
+        <resolver class="org.seasar.mayaa.impl.builder.injection.MetaValuesSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.ReplaceSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.RenderedSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InsertSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InjectAttributeInjectionResolver"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.EqualsIDInjectionResolver">
+            <parameter name="reportUnresolvedID" value="true"/>
+            <parameter name="reportDuplicatedID" value="true"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/TR/html4}id"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/1999/xhtml}id"/>
+        </resolver>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.XPathMatchesInjectionResolver"/>
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="outputMayaaWhitespace" value="false"/>
+        <parameter name="optimize" value="true"/>
+        <parameter name="defaultCharset" value="UTF-8"/><!-- since 1.1.22 -->
+        <parameter name="replaceSSIInclude" value="false"/><!-- since 1.1.25 -->
+        <parameter name="balanceTag" value="true"/><!-- since 1.1.29 -->
+    </templateBuilder>
+
+    <!--
+    <templateBuilder class="org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder">
+        <resolver class="org.seasar.mayaa.impl.builder.injection.MetaValuesSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.ReplaceSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.RenderedSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InsertSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InjectAttributeInjectionResolver"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.EqualsIDInjectionResolver">
+            <parameter name="reportUnresolvedID" value="true"/>
+            <parameter name="reportDuplicatedID" value="true"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/TR/html4}id"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/1999/xhtml}id"/>
+        </resolver>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.XPathMatchesInjectionResolver"/>
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="outputMayaaWhitespace" value="false"/>
+        <parameter name="optimize" value="true"/>
+        <parameter name="defaultCharset" value="UTF-8"/>
+        <parameter name="replaceSSIInclude" value="false"/>
+
+        <parameter name="defaultLayoutPageName" value="/defaultlayout.html"/>
+        <parameter name="generateMayaaNode" value="true"/>
+    </templateBuilder>
+    -->
+
+    <pathAdjuster class="org.seasar.mayaa.impl.builder.PathAdjusterImpl">
+        <parameter name="enabled" value="true"/>
+        <parameter name="force" value="false"/><!-- since 1.1.13 -->
+    </pathAdjuster>
+
+    <templateAttributeReader
+            class="org.seasar.mayaa.impl.builder.library.TemplateAttributeReaderImpl">
+        <!-- example
+        <ignoreAttribute
+                qName="{http://struts.apache.org/tags-html}errors"
+                attribute="id"/>
+        <aliasAttribute
+                qName="{http://struts.apache.org/tags-html}*"
+                attribute="styleId"
+                templateAttribute="id" />
+        -->
+        <parameter name="enabled" value="false"/>
+    </templateAttributeReader>
+
+    <parentSpecificationResolver class="org.seasar.mayaa.impl.engine.specification.ParentSpecificationResolverImpl">
+    </parentSpecificationResolver>
 
 </provider>

--- a/src/test/resources/it-case/script/java-bridge/expected.html
+++ b/src/test/resources/it-case/script/java-bridge/expected.html
@@ -1,0 +1,7 @@
+Content-Type:text/html;charset=UTF-8
+
+<html>
+    <body>
+        Java Runtime: TEST VALUE
+    </body>
+</html>

--- a/src/test/resources/it-case/script/java-bridge/target.html
+++ b/src/test/resources/it-case/script/java-bridge/target.html
@@ -1,0 +1,5 @@
+<html xmlns:m="http://mayaa.seasar.org">
+    <body>
+        <div m:id="env_value">ABC</div>
+    </body>
+</html>

--- a/src/test/resources/it-case/script/java-bridge/target.mayaa
+++ b/src/test/resources/it-case/script/java-bridge/target.mayaa
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<m:mayaa xmlns:m="http://mayaa.seasar.org">
+    <m:write m:id="env_value" value="Java Runtime: ${java.lang.System.getProperty('test.value')}" />
+</m:mayaa>


### PR DESCRIPTION
スクリプト実行を行う`Engine`のテストおよび `ScriptEnvironmentImpl` のテストを追加
IDE上でcontext/WEB-INF 配下の jar が pom.xml 定義のjarが競合するため .classpath からは除外した。
(WAR配布を今後も行わないなら context ディレクトリは以下は不要と思います)
