### PR TITLE
Mayaaのバージョンをmvnビルド時にソースに埋め込む

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Mayaa 1.1.35 : 未リリース
 ### Changes
+- [#35](https://github.com/seasarorg/mayaa/pull/35) - Mayaaのバージョンを`${org.seasar.mayaa.impl.Version.MAYAA_VERSION}`で参照できるようにしました。
 - [#15](https://github.com/seasarorg/mayaa/issues/15) - スクリプトのキャッシュの強制保持個数を指定できるようにしました。
 - [#16](https://github.com/seasarorg/mayaa/issues/16) - Mayaa動作要件の最低JavaバージョンをJava7としました。
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <!-- 普段はJUnitパフォーマンス計測用テスト、遅いテストは除外する -->
     <testExcludedGroups>test.PerformanceTest.class,test.SlowTest.class</testExcludedGroups>
     <testArgLine></testArgLine>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <profiles>
@@ -251,6 +252,19 @@
                 <source>src-impl</source>
               </sources>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java-templates/org/seasar/mayaa/impl/Version.java
+++ b/src/main/java-templates/org/seasar/mayaa/impl/Version.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2004-2012 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.impl;
+
+/*
+ * Mayaaのリリースバージョンを保持するクラス。
+ * Mavenビルド時に pom.xml で指定されているバージョンに置換される。
+ */
+public class Version {
+    public static final String MAYAA_VERSION = "${project.version}";
+}


### PR DESCRIPTION
org.seasar.mayaa.impl.Version.MAYAA_VERSION で参照可能