### PR TITLE
CDATAプロセッサの入れ子で意図せず]]>が出力されないように出力制御

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/TemplateBuilderImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/TemplateBuilderImpl.java
@@ -479,6 +479,7 @@ public class TemplateBuilderImpl extends SpecificationBuilderImpl
             }
         }
 
+        // expandsとして展開された同階層のLiteralCharactersProcessorが連続している場合は結合する
         List<ProcessorTreeWalker> packs = new ArrayList<>();
         for (int i = 0; i < expands.size(); i++) {
             ProcessorTreeWalker node = (ProcessorTreeWalker) expands.get(i);

--- a/src/test/java/org/seasar/mayaa/functional/EngineTestBase.java
+++ b/src/test/java/org/seasar/mayaa/functional/EngineTestBase.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
@@ -159,7 +160,14 @@ public class EngineTestBase {
         engine.doService(pageScopeAttribute, true);
 
         // verify(servletContext).getRealPath(path);
-
+        if ("true".equals(engine.getParameter(EngineImpl.DUMP_ENABLED))) {
+            try {
+                final String content = response.getContentAsString();
+                System.out.println(content);
+            }
+            catch (UnsupportedEncodingException e) {
+            }
+        }
         return response;
     }
 

--- a/src/test/java/org/seasar/mayaa/functional/ProcessorTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/ProcessorTest.java
@@ -70,4 +70,11 @@ public class ProcessorTest extends EngineTestBase {
         }
 
     }
+
+    @Test
+    public void プロセッサcdataで子要素をCDATAで囲む() throws IOException {
+        enableDump();
+        execAndVerify(BASE_PATH + "cdata/target.html", BASE_PATH + "cdata/expected.html", null);
+    }
+
 }

--- a/src/test/resources/it-case/html-transform/processors/cdata/expected.html
+++ b/src/test/resources/it-case/html-transform/processors/cdata/expected.html
@@ -1,0 +1,24 @@
+<html>
+  <body>
+    <section id="1">
+      <![CDATA[
+        var val_int = 0;
+      ]]>
+    </section>
+    <section id="2">
+      <![CDATA[
+        <p>子要素のテキスト1</p>
+        TEXT
+      ]]>
+    </section>
+    <section id="3">
+      <![CDATA[
+        <p>子要素のテキスト1</p>
+        
+          <p>子要素のテキスト2</p>
+          TEXT
+        
+      ]]>
+    </section>
+  </body>
+</html>

--- a/src/test/resources/it-case/html-transform/processors/cdata/target.html
+++ b/src/test/resources/it-case/html-transform/processors/cdata/target.html
@@ -1,0 +1,24 @@
+<html xmlns:m="http://mayaa.seasar.org">
+  <body>
+    <section id="1" m:comment="子要素は単純テキスト">
+      <div m:id="CDATA:">
+        var val_int = 0;
+      </div>
+    </section>
+    <section id="2" m:comment="子要素にプロセッサを含む">
+      <div m:id="CDATA:">
+        <p>子要素のテキスト1</p>
+        <p m:id="WRITE:TEXT">子要素のテキスト2</p>
+      </div>
+    </section>
+    <section id="3" m:comment="子要素にCDATAプロセッサを入れ子で含む">
+      <div m:id="CDATA:">
+        <p>子要素のテキスト1</p>
+        <div m:id="CDATA:">
+          <p>子要素のテキスト2</p>
+          <p m:id="WRITE:TEXT">子要素のテキスト2</p>
+        </div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/src/test/resources/it-case/html-transform/processors/cdata/target.mayaa
+++ b/src/test/resources/it-case/html-transform/processors/cdata/target.mayaa
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<m:mayaa xmlns:m="http://mayaa.seasar.org">
+
+    <m:cdata m:id="CDATA:" />
+
+    <m:write m:id="WRITE:TEXT" value="TEXT" />
+
+</m:mayaa>


### PR DESCRIPTION
CDATAは入れ子が許されていない。

CDATAProcessorを入れ子で使用すると各プロセッサで &lt;![CDATA[ および ]]> を出力するため
意図せずCDATAが閉じてしまう。
このため、ネストレベルを管理して、内側のCDATAProcessorでは &lt;![CDATA[ および ]]> を出力しないようにする。

入れ子を検知した段階で例外を出力した方がよければコメントください。
