### PR TITLE
Java7互換性の修正漏れ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,15 +575,26 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.0.16.RELEASE</version>
+      <version>4.3.29.RELEASE</version>
       <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.0.16.RELEASE</version>
-      <scope>test</scope>
+      <version>4.3.29.RELEASE</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.activation/javax.activation-api -->
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.sun.activation/javax.activation -->
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/javax.servlet.jsp.jstl/jstl-api -->
     <dependency>

--- a/src-impl/org/seasar/mayaa/impl/source/SystemIDFileSearchIterator.java
+++ b/src-impl/org/seasar/mayaa/impl/source/SystemIDFileSearchIterator.java
@@ -96,6 +96,11 @@ public class SystemIDFileSearchIterator extends FileSearchIterator implements It
         return makeSystemID((File) super.nextFile());
     }
 
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
     protected String makeSystemID(File current) {
         String rootPath = getRoot().getPath();
         String filePath = current.getPath();


### PR DESCRIPTION
pom.xml で java7 ターゲットにしているものの、手元では java8 コンパイラを使用していたことに起因して
Java8ではデフォルトメソッドとなっていたIterator.remove の未実装箇所の検知が漏れた。

Github Action で使用するJDKのバージョンを 7 に変更したことにより発覚した。
