### PR TITLE
URLエンコードされる文字を含むsystemIDのファイル実体が参照できない

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/util/IOUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/util/IOUtil.java
@@ -22,9 +22,12 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -184,10 +187,16 @@ public class IOUtil {
      * @param url 対象のURL
      * @return ファイルプロトコルならtrue
      */
+    @SuppressWarnings("deprecation")
     public static File getFile(URL url) {
         if (url != null) {
             if ("file".equalsIgnoreCase(url.getProtocol())) {
-                return new File(url.toString().substring(5));
+                try {
+                    return new File(URLDecoder.decode(url.getFile(), StandardCharsets.UTF_8.name()));
+                } catch (UnsupportedEncodingException e) {
+                    // UTF-8 で発生しないはずだが、フォールバックとしてデフォルトエンコーディングとする。
+                    return new File(URLDecoder.decode(url.getFile()));
+                }
             }
         }
         return null;

--- a/src/test/java/org/seasar/mayaa/impl/util/IOUtilTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/util/IOUtilTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLDecoder;
 
 import org.junit.After;
 import org.junit.Before;
@@ -113,7 +115,7 @@ public class IOUtilTest {
         assertNotNull(url);
 
         long fileLastModified = IOUtil.getLastModified(url);
-        File testFile = new File(url.toString().substring(5));
+        File testFile = new File(URLDecoder.decode(url.toString().substring(5), "UTF-8"));
         assertEquals(testFile.lastModified(), fileLastModified);
 
         URL urlInJar = getLoader().getResource("junit/framework/TestCase.class");
@@ -136,7 +138,7 @@ public class IOUtilTest {
         InputStream actualIS = null;
         try {
             expectedIS = IOUtil.openStream(expected);
-            actualIS = IOUtil.openStream(actual.toURL());
+            actualIS = new FileInputStream(actual);
             String expectedString = IOUtil.readStream(expectedIS, encoding);
             String actualString = IOUtil.readStream(actualIS, encoding);
             assertEquals(expectedString, actualString);
@@ -144,7 +146,7 @@ public class IOUtilTest {
             IOUtil.close(expectedIS);
             IOUtil.close(actualIS);
         }
-        assertEquals(expected, actual.toURL());
+        assertEquals(expected, actual.toURI().toURL());
     }
 
     /**


### PR DESCRIPTION
URLエンコードされる文字を含むsystemIDのファイル実体が参照できない。
仕様として systemID にURLエンコードされる文字を含むことがあり得るのかどうか。

影響範囲はClassLoader.getResource(String)で取得されたURLオブジェクトを受け取っている箇所であり、
現状ではClassLoaderSourceDescriptorから参照されるもののみ。

テストケースの見直しにより検出したもの。
