### PR TITLE
IS_SECURE_WEB 設定をParameterAwareからEngineUtilに移動

### DIFF
--- a/src-api/org/seasar/mayaa/ParameterAware.java
+++ b/src-api/org/seasar/mayaa/ParameterAware.java
@@ -24,16 +24,6 @@ import java.util.Iterator;
 public interface ParameterAware extends PositionAware {
 
     /**
-     * IS_SECURE_WEBのキー。
-     */
-    String SECURE_WEB_KEY = "org.seasar.mayaa.secure.web";
-
-    /**
-     * Google App Engineのような、セキュアなWeb環境設定か否か
-     */
-    boolean IS_SECURE_WEB = Boolean.getBoolean(SECURE_WEB_KEY);
-
-    /**
      * ユーザー設定の受け入れメソッド。
      * @param name 設定名。
      * @param value 設定値。

--- a/src-impl/org/seasar/mayaa/impl/AutoPageBuilder.java
+++ b/src-impl/org/seasar/mayaa/impl/AutoPageBuilder.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.FactoryFactory;
-import org.seasar.mayaa.ParameterAware;
 import org.seasar.mayaa.cycle.ServiceCycle;
 import org.seasar.mayaa.engine.Engine;
 import org.seasar.mayaa.engine.Page;
@@ -33,6 +32,7 @@ import org.seasar.mayaa.engine.specification.Specification;
 import org.seasar.mayaa.impl.cycle.CycleUtil;
 import org.seasar.mayaa.impl.cycle.web.MockHttpServletRequest;
 import org.seasar.mayaa.impl.cycle.web.MockHttpServletResponse;
+import org.seasar.mayaa.impl.engine.EngineUtil;
 import org.seasar.mayaa.impl.provider.ProviderUtil;
 import org.seasar.mayaa.impl.source.ApplicationSourceDescriptor;
 import org.seasar.mayaa.impl.source.SourceHolderFactory;
@@ -104,7 +104,7 @@ public class AutoPageBuilder implements Runnable {
         Engine engine = ProviderUtil.getEngine();
         boolean autoBuild = ObjectUtil.booleanValue(
                 engine.getParameter(OPTION_AUTO_BUILD), false);
-        if (autoBuild && (ParameterAware.IS_SECURE_WEB == false)) {
+        if (autoBuild && !EngineUtil.isInSecureWeb()) {
             _servletContext = servletConfig.getServletContext();
             _contextPath = prepareContextPath(contextPath, engine);
             _repeat = ObjectUtil.booleanValue(

--- a/src-impl/org/seasar/mayaa/impl/CONST_IMPL.java
+++ b/src-impl/org/seasar/mayaa/impl/CONST_IMPL.java
@@ -25,6 +25,11 @@ import org.seasar.mayaa.impl.engine.specification.URIImpl;
  */
 public interface CONST_IMPL {
 
+    /**
+     * IS_SECURE_WEBのキー。
+     */
+    String SECURE_WEB_KEY = "org.seasar.mayaa.secure.web";
+
     String DEBUG = "org.seasar.mayaa.debug";
 
     String CHECK_TIMESTAMP = "checkTimestamp";

--- a/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
@@ -45,6 +45,13 @@ public class EngineUtil implements CONST_IMPL {
     private static String _mayaaExtensionName;
 
     /**
+     * Google App Engineのような、セキュアなWeb環境設定か否か
+     */
+    public static boolean isInSecureWeb() {
+        return Boolean.getBoolean(CONST_IMPL.SECURE_WEB_KEY);
+    }
+
+    /**
      * 現在デバッグモードかどうかを返します。
      * @return 現在がデバッグモードなら{@code true}、そうでなければ{@code false}。
      */

--- a/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
@@ -45,7 +45,10 @@ public class EngineUtil implements CONST_IMPL {
     private static String _mayaaExtensionName;
 
     /**
-     * Google App Engineのような、セキュアなWeb環境設定か否か
+     * Google App Engineのような、セキュアなWeb環境設定か否かを返却する。
+     * 有効にする場合はシステムプロパティ org.seasar.mayaa.secure.web に true を設定する。
+     * 
+     * @return セキュアなWeb環境の設定がされている場合は true
      */
     public static boolean isInSecureWeb() {
         return Boolean.getBoolean(CONST_IMPL.SECURE_WEB_KEY);

--- a/src-impl/org/seasar/mayaa/impl/engine/SpecificationCache.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/SpecificationCache.java
@@ -49,7 +49,7 @@ public class SpecificationCache {
 
     public SpecificationCache(int surviveLimit) {
         _surviveLimit = surviveLimit;
-        if (surviveLimit > 0 && !ParameterAware.IS_SECURE_WEB) {
+        if (surviveLimit > 0 && !EngineUtil.isInSecureWeb()) {
             _gcChecker = new ReferenceCache<>(Object.class,
                     ReferenceCache.SOFT, new GCReceiver());
             postNewGabage();

--- a/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationImpl.java
@@ -74,7 +74,7 @@ public class SpecificationImpl extends ParameterAwareImpl
     }
 
     public boolean isSpecificationSerialize() {
-        return _specificationSerialize && !IS_SECURE_WEB;
+        return _specificationSerialize && !EngineUtil.isInSecureWeb();
     }
 
     public void setSpecificationSerialize(boolean specificationSerialize) {

--- a/src-impl/org/seasar/mayaa/impl/source/FileSourceDescriptor.java
+++ b/src-impl/org/seasar/mayaa/impl/source/FileSourceDescriptor.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.impl.ParameterAwareImpl;
 import org.seasar.mayaa.impl.cycle.CycleUtil;
+import org.seasar.mayaa.impl.engine.EngineUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
 import org.seasar.mayaa.source.WritableSourceDescriptor;
 
@@ -87,7 +88,7 @@ public class FileSourceDescriptor
             String realPath = getRealPath();
             if (StringUtil.hasValue(realPath)) {
                  File file = new File(realPath);
-                 if (IS_SECURE_WEB) {
+                 if (EngineUtil.isInSecureWeb()) {
                 	 try {
                 		 if (file.exists()) {
                 			 _file = file;

--- a/src-impl/org/seasar/mayaa/impl/source/PageSourceFactoryImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/source/PageSourceFactoryImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.impl.IllegalParameterValueException;
 import org.seasar.mayaa.impl.ParameterAwareImpl;
+import org.seasar.mayaa.impl.engine.EngineUtil;
 import org.seasar.mayaa.impl.util.ObjectUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
 import org.seasar.mayaa.source.SourceDescriptor;
@@ -118,7 +119,7 @@ public class PageSourceFactoryImpl extends ParameterAwareImpl
 
         Class<?> sourceHolderClass = null;
         if ("folder".equals(name)) {
-        	if (IS_SECURE_WEB && ("".equals(value) || "/".equals(value))) {
+        	if (EngineUtil.isInSecureWeb() && ("".equals(value) || "/".equals(value))) {
         		sourceHolderClass = WebContextRootResourceHolder.class;
         	} else {
         		sourceHolderClass = WebContextFolderSourceHolder.class;


### PR DESCRIPTION
ParameterAwareImplに対するSerializableが強すぎて、ほぼ全てのクラスがserialVersionUIDを要求されている状態であるため、
Serializableをつけるインタフェースを再調整する。
本件はそのための準備として ParameterAware インタフェースから IS_SECURE_WEB の判定参照をEngineUtilに移動する。