### PR TITLE
balanceTag を無効にするとDOCTYPEが<head>内に余分に付加される

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/SpecificationNodeHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/SpecificationNodeHandler.java
@@ -80,6 +80,7 @@ public abstract class SpecificationNodeHandler
     private int _charactersStartLineNumber;
     private boolean _outputMayaaWhitespace = false;
     private boolean _inCData;
+    private SpecificationNode _xmlDeclNode = null;
 
     /**
      * {@link Specification} をファイルから読み込む際の最上位の名前空間設定を返す。
@@ -377,9 +378,12 @@ public abstract class SpecificationNodeHandler
 
     @Override
     public void xmlDecl(String version, String encoding, String standalone) {
-        addCharactersNode();
-        SpecificationNode node = addNode(QM_PI);
-        node.addAttribute(QM_TARGET, "xml");
+        if (_xmlDeclNode == null) {
+            addCharactersNode();
+            _xmlDeclNode = addNode(QM_PI);
+        }
+        _xmlDeclNode.removeAttribute(QM_TARGET);
+        _xmlDeclNode.addAttribute(QM_TARGET, "xml");
         StringBuilder buffer = new StringBuilder();
         if (StringUtil.hasValue(version)) {
             buffer.append("version=\"").append(version).append("\" ");
@@ -391,8 +395,9 @@ public abstract class SpecificationNodeHandler
         if (StringUtil.hasValue(standalone)) {
             buffer.append("standalone=\"").append(standalone).append("\" ");
         }
+        _xmlDeclNode.removeAttribute(QM_DATA);
         if (buffer.length() > 0) {
-            node.addAttribute(QM_DATA, buffer.toString().trim());
+            _xmlDeclNode.addAttribute(QM_DATA, buffer.toString().trim());
         }
     }
 

--- a/src-impl/org/seasar/mayaa/impl/builder/TemplateNodeHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/TemplateNodeHandler.java
@@ -58,6 +58,7 @@ public class TemplateNodeHandler extends SpecificationNodeHandler implements Ent
     private boolean inDTD = false;
     private boolean _outputTemplateWhitespace = true;
     private boolean _isSSIIncludeReplacementEnabled = false;
+    private SpecificationNode _dtdNode = null;
 
     public TemplateNodeHandler(Template specification) {
         super(specification);
@@ -517,14 +518,20 @@ public class TemplateNodeHandler extends SpecificationNodeHandler implements Ent
     @Override
     public void startDTD(String name, String publicID, String systemID) {
         inDTD = true;
-        addCharactersNode();
-        SpecificationNode node = addNode(QM_DOCTYPE);
-        node.addAttribute(QM_NAME, name);
-        if (StringUtil.hasValue(publicID)) {
-            node.addAttribute(QM_PUBLIC_ID, publicID);
+        if (_dtdNode == null) {
+            addCharactersNode();
+            _dtdNode = addNode(QM_DOCTYPE);
         }
+        _dtdNode.removeAttribute(QM_NAME);
+        _dtdNode.addAttribute(QM_NAME, name);
+
+        _dtdNode.removeAttribute(QM_PUBLIC_ID);
+        if (StringUtil.hasValue(publicID)) {
+            _dtdNode.addAttribute(QM_PUBLIC_ID, publicID);
+        }
+        _dtdNode.removeAttribute(QM_SYSTEM_ID);
         if (StringUtil.hasValue(systemID)) {
-            node.addAttribute(QM_SYSTEM_ID, systemID);
+            _dtdNode.addAttribute(QM_SYSTEM_ID, systemID);
         }
 
         // TODO doctype宣言後の改行をテンプレート通りにしたあと削除

--- a/src/test/java/org/seasar/mayaa/functional/engine/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
+++ b/src/test/java/org/seasar/mayaa/functional/engine/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
@@ -108,7 +108,7 @@
         <parameter name="optimize" value="true"/>
         <parameter name="defaultCharset" value="UTF-8"/><!-- since 1.1.22 -->
         <parameter name="replaceSSIInclude" value="true"/><!-- since 1.1.25 -->
-        <parameter name="balanceTag" value="true"/><!-- since 1.1.29 -->
+        <parameter name="balanceTag" value="false"/><!-- since 1.1.29 -->
     </templateBuilder>
 
     <!--


### PR DESCRIPTION
Fixes #75
ソースのHTMLに meta http-equiv="content-type" で charset が指定されているときに nekohtml で
読み込みストリームを再オープンするため。この meta タグの記述より前の部分については既にパーサーから
startElementなどのハンドラが呼び出されているため、再オープン後は呼び出されず、xmlDecl やstartDTDだけが呼び出される。
```html
	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
```
従って、２回目に xmlDecl, statDTDが呼び出されたときはノードを追加するのではなく、上書きする。