### PR TITLE
動的に登録されたインメモリコンテンツを返却するSourceHolderを追加

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -25,7 +25,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.project
+++ b/.project
@@ -23,12 +23,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1603724237018</id>
+			<id>1665278751498</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/src-impl/org/seasar/mayaa/impl/provider/factory/ParameterTagHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/provider/factory/ParameterTagHandler.java
@@ -39,7 +39,12 @@ public class ParameterTagHandler extends TagHandler {
             Attributes attributes, String systemID, int lineNumber) {
         String name = XMLUtil.getStringValue(attributes, "name", null);
         String value = XMLUtil.getStringValue(attributes, "value", null);
-        value = StringUtil.replaceSystemProperties(value);
+
+        if (value != null) {
+            value = StringUtil.replaceSystemProperties(value);
+        } else {
+            value = "";
+        }
         _parent.getParameterAware().setParameter(name, value);
     }
 

--- a/src-impl/org/seasar/mayaa/impl/source/DynamicRegisteredSourceHolder.java
+++ b/src-impl/org/seasar/mayaa/impl/source/DynamicRegisteredSourceHolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2004-2022 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.impl.source;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Mitsutaka Watanabe
+ */
+public class DynamicRegisteredSourceHolder
+        extends SourceDescriptorProvideSourceHolder {
+
+    protected ChangeableRootSourceDescriptor getSourceDescriptor() {
+        return new InMemorySourceDescriptor(this);
+    }
+
+    public void setRoot(String root) {
+        // NOP
+    }
+
+    public String getContents(String systemId) {
+        return contentRepository.get(systemId);
+    }
+
+    public Date getTimestamp(String systemId) {
+        return contentTimestamp.get(systemId);
+    }
+
+    private static Map<String, String> contentRepository = new HashMap<>();
+    private static Map<String, Date> contentTimestamp = new HashMap<>();
+    
+    public static void registerContents(String systemId, String content) {
+        contentRepository.put(systemId, content);
+        contentTimestamp.put(systemId, new Date());
+    }
+
+    public static void unregisterContents(String systemId) {
+        contentRepository.remove(systemId);
+        contentTimestamp.remove(systemId);
+    }
+
+    public static void unregisterAll() {
+        contentRepository.clear();
+        contentTimestamp.clear();
+    }
+}

--- a/src-impl/org/seasar/mayaa/impl/source/InMemorySourceDescriptor.java
+++ b/src-impl/org/seasar/mayaa/impl/source/InMemorySourceDescriptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2004-2022 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.impl.source;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Date;
+
+import org.seasar.mayaa.impl.util.StringUtil;
+
+/**
+ * @author Mitsutaka Watanabe
+ */
+public class InMemorySourceDescriptor implements ChangeableRootSourceDescriptor {
+
+    private static final Date NOTFOUND_TIMESTAMP = new Date(0);
+
+    private DynamicRegisteredSourceHolder sourceHolder;
+
+    private String _systemID = "";
+
+    public InMemorySourceDescriptor(DynamicRegisteredSourceHolder sourceHolder) {
+        this.sourceHolder = sourceHolder;
+    }
+
+    public void setRoot(String root) {
+    }
+
+    public String getRoot() {
+        return "";
+    }
+
+    public void setSystemID(String systemID) {
+        _systemID = StringUtil.preparePath(systemID);
+    }
+
+    @Override
+    public String getSystemID() {
+        return _systemID;
+    }
+
+    public boolean exists() {
+        String content = sourceHolder.getContents(_systemID);
+        return content != null && !content.isEmpty();
+    }
+
+    public InputStream getInputStream() {
+        String content = sourceHolder.getContents(_systemID);
+        if (content != null && !content.isEmpty()) {
+            try {
+                return new ByteArrayInputStream(content.getBytes("UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public Date getTimestamp() {
+        Date timestamp = sourceHolder.getTimestamp(_systemID);
+        if (timestamp != null) {
+            return timestamp;
+        }
+        return NOTFOUND_TIMESTAMP;
+    }
+}

--- a/src-impl/org/seasar/mayaa/impl/source/PageSourceFactoryImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/source/PageSourceFactoryImpl.java
@@ -131,6 +131,8 @@ public class PageSourceFactoryImpl extends ParameterAwareImpl
         	}
         } else if ("absolutePath".equals(name)) {
             sourceHolderClass = AbsolutePathSourceHolder.class;
+        } else if ("dynamic".equals(name)) {
+            sourceHolderClass = DynamicRegisteredSourceHolder.class;
         } else {
             super.setParameter(name, value);
             return;

--- a/src/integration-test/resources/META-INF/org.seasar.mayaa.source.PageSourceFactory
+++ b/src/integration-test/resources/META-INF/org.seasar.mayaa.source.PageSourceFactory
@@ -3,6 +3,7 @@
    PUBLIC "-//The Seasar Foundation//DTD Mayaa Factory 1.0//EN"
    "http://mayaa.seasar.org/dtd/mayaa-factory_1_0.dtd">
 <factory>
+	<parameter name="dynamic" value="" />
    <parameter name="folder" value="/WEB-INF/page1" />
    <parameter name="folder" value="/WEB-INF/page2" />
 </factory>

--- a/test-war/pom.xml
+++ b/test-war/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>com.github.seasarorg.mayaa</groupId>
       <artifactId>mayaa</artifactId>
-      <version>[1.1,)</version>
+      <version>1.1.34</version>
     </dependency>
     <dependency><!-- for custom tags -->
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
主な用途はテスト用でテストケース内で下記のような利用方法を想定。

```java
final String DIR = "/it-case/parser/dynamic/";
DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", 
"<!doctype html>\n" +
"<html>" +
"<DIV>${var a='no body';}${a.toUpperCase()}</DIV>" +
"</html>"
);
DynamicRegisteredSourceHolder.registerContents(DIR + "expected.html", 
"<!DOCTYPE html>\n" +
"<html>" +
"<div>NO BODY</div>" +
"</html>"
);

execAndVerify(DIR + "target.html", DIR + "expected.html", null);
DynamicRegisteredSourceHolder.unregisterAll();
```

org.seasar.mayaa.source.PageSourceFactory に `dynamic` というパラメータを追加することで追加される。

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE factory PUBLIC "-//The Seasar Foundation//DTD Mayaa Factory 1.0//EN" "http://mayaa.seasar.org/dtd/mayaa-factory_1_0.dtd">
<factory>
   <parameter name="dynamic" value="" />
   <parameter name="folder" value="/WEB-INF/page" />
</factory>
```