### PR TITLE
Java8 向けのAPI利用に制限する。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,7 @@
     <!-- 普段はJUnitパフォーマンス計測用テスト、遅いテストは除外する -->
     <testExcludedGroups>test.PerformanceTest.class,test.SlowTest.class</testExcludedGroups>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <profiles>
@@ -197,15 +196,15 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
           <configuration>
             <encoding>UTF-8</encoding>
-            <source>1.8</source>
-            <target>1.8</target>
             <compilerArgument>-Xlint:deprecation</compilerArgument>
           </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
           <configuration>
             <encoding>UTF-8</encoding>
           </configuration>
@@ -213,7 +212,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M7</version>
           <configuration>
             <excludedGroups>${testExcludedGroups}</excludedGroups>
             <argLine>${jacocoArgs} -Xmx2048m</argLine>
@@ -227,7 +226,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>source-jar</id>
@@ -240,7 +239,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.1</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <docencoding>UTF-8</docencoding>


### PR DESCRIPTION
Java8 でないコンパイラでビルドした時に標準JavaクラスAPIが使われていたのを修正