### PR TITLE
ResourceScannerで全てのJarをスキャンしないように除外指定できる

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/library/LibraryManagerImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/LibraryManagerImpl.java
@@ -165,10 +165,27 @@ public class LibraryManagerImpl extends NonSerializableParameterAwareImpl
 
                     _libraries.put(library.getNamespaceURI(), library);
                     if (LOG.isInfoEnabled()) {
-                        LOG.info(StringUtil.getMessage(
-                            LibraryManagerImpl.class, 4,
-                            source.getSystemID(),
-                            String.valueOf(library.getNamespaceURI())));
+                        // 読み込み元のファイルがJARファイルの場合はファイル名をログに出力
+                        String containerFile = null;
+                        if (source instanceof HavingAliasSourceDescriptor) {
+                            final SourceAlias alias = ((HavingAliasSourceDescriptor) source).getAlias();
+                            if (alias != null) {
+                                containerFile = alias.getAlias();
+                            }
+                        }
+                        if (containerFile == null) {
+                            LOG.info(StringUtil.getMessage(
+                                LibraryManagerImpl.class, 4,
+                                source.getSystemID(),
+                                String.valueOf(library.getNamespaceURI())));
+                        } else {
+                            LOG.info(StringUtil.getMessage(
+                                LibraryManagerImpl.class, 5,
+                                source.getSystemID(),
+                                String.valueOf(library.getNamespaceURI()),
+                                containerFile
+                            ));
+                        }
                     }
                     built = true;
                     break;

--- a/src-impl/org/seasar/mayaa/impl/builder/library/message.properties
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/message.properties
@@ -5,6 +5,7 @@ LibraryManagerImpl.1=Converter "{0}"({1}#{2}) has been registed.
 LibraryManagerImpl.2=SourceScanner "{0}"({1}#{2}) has been registed.
 LibraryManagerImpl.3=DefinitionBuilder "{0}"({1}#{2}) has been registed.
 LibraryManagerImpl.4=loaded library - {0} - {1}
+LibraryManagerImpl.5=loaded library - {0} - {1} from {2}
 LibraryDefinitionImpl.1=Converter "{0}"({1}#{2}) has been registed.
 LibraryDefinitionImpl.2=PropertySet "{0}"({1}#{2}) has been registed.
 LibraryDefinitionImpl.3=Processor "{0}"({1}#{2}) has been registed.

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/FolderSourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/FolderSourceScanner.java
@@ -45,6 +45,7 @@ public class FolderSourceScanner extends ParameterAwareImpl
 
     private FileSourceDescriptor _source;
 
+    private String _root;
     private String _folder;
 
     private boolean _recursive = false;
@@ -84,7 +85,14 @@ public class FolderSourceScanner extends ParameterAwareImpl
                 appScope = appSource.getApplicationScope();
                 _source = appSource;
             }
-            _source.setRoot(getFolder());
+
+            if (StringUtil.isEmpty(_root)) {
+//                _source.setSystemID("/" + _folder);
+                _source.setRoot(getFolder());
+            } else {
+                _source.setSystemID("/" + _folder);
+                _source.setRoot(_root);
+            }
         }
         if (_source.exists() && _source.isDirectory()) {
             return new FileToSourceIterator(appScope,
@@ -170,6 +178,11 @@ public class FolderSourceScanner extends ParameterAwareImpl
                 throw new IllegalParameterValueException(getClass(), name);
             }
             _folder = value;
+        } else if ("root".equals(name)) {
+            if (StringUtil.isEmpty(value)) {
+                throw new IllegalParameterValueException(getClass(), name);
+            }
+            _root = value;
         } else if ("recursive".equals(name)) {
             _recursive = Boolean.valueOf(value).booleanValue();
         } else if ("absolute".equals(name)) {
@@ -248,7 +261,7 @@ public class FolderSourceScanner extends ParameterAwareImpl
             if (_applicationScope != null) {
                 root = _applicationScope.getRealPath(sourceRoot);
             } else {
-                root = "";
+                root = sourceRoot;
             }
             String absolutePath = file.getAbsolutePath();
             String path = absolutePath.substring(root.length());

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
@@ -79,16 +79,22 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
             if (path.charAt(path.length()-1) != File.separatorChar) {
                 path += File.separatorChar;
             }
+
+            String folder;
             if (_root != null) {
-                path += _root;
-                File dir = new File(path);
+                File dir = new File(path, _root);
                 if (dir.exists() == false || dir.isDirectory() == false) {
                     continue;
                 }
+                folder = _root;
+            } else {
+                folder = "/";
             }
 
+
             FolderSourceScanner folderScanner = new FolderSourceScanner();
-            folderScanner.setParameter("folder", path);
+            folderScanner.setParameter("root", path);    // Classpath root
+            folderScanner.setParameter("folder", folder); // Iteration target folder
             folderScanner.setParameter("recursive", "true");
             folderScanner.setParameter("absolute", "true");
             for (String extension : _extensions) {

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
@@ -16,6 +16,9 @@
 package org.seasar.mayaa.impl.builder.library.scanner;
 
 import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,25 +47,30 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
     private List<String> _jars = new ArrayList<>();
     private Set<String> _extensions = new HashSet<>();
     private Set<String> _ignores = new HashSet<>();
+    private JarMatcher _jarMatcher = new JarMatcher();
 
     public ResourceScanner() {
-        String[] pathArray = System.getProperty(
-                "java.class.path", ".").split(File.pathSeparator);
-        for (int i = 0; i < pathArray.length; i++) {
-            String path = pathArray[i];
-            File file = new File(path);
-            if (file.exists()) {
-                if (file.isDirectory()) {
-                    _classPath.add(path);
-                } else if (file.getName().endsWith(".jar")) {
-                    _jars.add(path);
-                }
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")
     public Iterator<SourceDescriptor> scan() {
+        // classpath要素を分解してスキャン対象を決定。
+        // includeJar, excludeJarの指定が存在しない場合は互換性のため全てのJarを含める
+        String[] pathArray = System.getProperty("java.class.path", ".").split(File.pathSeparator);
+        for (String path: pathArray) {
+            File file = new File(path);
+            if (!file.exists()) {
+                continue;
+            }
+            if (file.isDirectory()) {
+                _classPath.add(path);
+            } else if (file.getName().endsWith(".jar")) {
+                if (_jarMatcher.matches(file.toPath().getFileName())) {
+                    _jars.add(path);
+                }
+            }
+        }
+
         IteratorIterator itit = new IteratorIterator();
         for (String path : _classPath) {
             if (StringUtil.isEmpty(path)) {
@@ -122,7 +130,6 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
     }
 
     // Parameterizable implements ------------------------------------
-
     public void setParameter(String name, String value) {
         if ("root".equals(name)) {
             _root = value;
@@ -135,8 +142,46 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
             _extensions.add(value);
         } else if ("ignore".equals(name)) {
             _ignores.add(value);
+        } else if ("includeJar".equals(name)) {
+            _jarMatcher.include(value);
+        } else if ("excludeJar".equals(name)) {
+            _jarMatcher.exclude(value);
         } else {
             super.setParameter(name, value);
+        }
+    }
+
+    /**
+     * Jarファイル名に対してGlobパターンで含む(include)・除外する(exclude)を順番に追加管理する。
+     * 評価時は指定された順番で行い、最初にパターンに一致した結果を返す
+     */
+    class JarMatcher {
+        List<JarMatcherElement> _jarMatchers = new ArrayList<>();
+        class JarMatcherElement {
+            boolean isInclude;
+            PathMatcher matcher;
+            JarMatcherElement(String globPattern, boolean isInclude) {
+                this.isInclude = isInclude;
+                this.matcher = FileSystems.getDefault().getPathMatcher("glob:" + globPattern);
+            }
+        }
+
+        void include(String globPattern) {
+            _jarMatchers.add(new JarMatcherElement(globPattern, true));
+        }
+        void exclude(String globPattern) {
+            _jarMatchers.add(new JarMatcherElement(globPattern, false));
+        }
+
+        boolean matches(Path jarPath) {
+            for (JarMatcherElement elm: _jarMatchers) {
+                final boolean match = elm.matcher.matches(jarPath);
+                if (match) {
+                    // 最初にマッチした結果を返す。
+                    return elm.isInclude;
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/test/java/org/seasar/mayaa/functional/engine/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
+++ b/src/test/java/org/seasar/mayaa/functional/engine/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
@@ -79,6 +79,8 @@
             <parameter name="ignore" value="META-INF/MANIFEST.MF"/>
             <parameter name="extension" value=".mld"/>
             <parameter name="extension" value=".tld"/>
+            <parameter name="includeJar" value="taglibs-standard-*.jar"/>
+            <parameter name="excludeJar" value="*"/>
         </scanner>
 
         <scanner class="org.seasar.mayaa.impl.builder.library.scanner.DefaultSourceScanner"/>

--- a/src/test/java/org/seasar/mayaa/impl/builder/library/scanner/ResourceScannerTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/builder/library/scanner/ResourceScannerTest.java
@@ -1,0 +1,150 @@
+package org.seasar.mayaa.impl.builder.library.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.seasar.mayaa.impl.source.ApplicationFileSourceDescriptor;
+import org.seasar.mayaa.source.SourceDescriptor;
+import org.seasar.mayaa.test.util.ManualProviderFactory;
+
+public class ResourceScannerTest {
+  private ResourceScanner scanner;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+      ManualProviderFactory.setUp(this);
+      ManualProviderFactory.SCRIPT_ENVIRONMENT.initScope();
+
+      scanner = new ResourceScanner();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+      ManualProviderFactory.tearDown();
+  }
+
+  @Test
+  public void testScanDefault() {
+      scanner.setParameter("root", "META-INF/");
+      scanner.setParameter("extension", ".mld");
+      scanner.setParameter("extension", ".tld");
+      scanner.setParameter("ignore", "META-INF/MANIFEST.MF");
+
+      List<String> expected = Arrays.asList(
+        "/META-INF/TestTag.tld",
+        "/META-INF/c.tld",
+        "/META-INF/c-1_0-rt.tld",
+        "/META-INF/c-1_1.tld",
+        "/META-INF/fmt-1_0-rt.tld",
+        "/META-INF/fmt.tld",
+        "/META-INF/fn.tld",
+        "/META-INF/permittedTaglibs.tld",
+        "/META-INF/scriptfree.tld",
+        "/META-INF/sql-1_0-rt.tld",
+        "/META-INF/sql.tld",
+        "/META-INF/x-1_0-rt.tld",
+        "/META-INF/x.tld"
+      );
+
+      List<String> sources = new ArrayList<>();
+      scanner.scan().forEachRemaining(e -> {
+        sources.add(e.getSystemID());
+      });
+
+      Collections.sort(sources);
+      Collections.sort(expected);
+      assertIterableEquals(expected, sources);
+  }
+
+  @Test
+  public void testScanIncludeExcludeJar() {
+      scanner.setParameter("root", "META-INF/");
+      scanner.setParameter("extension", ".mld");
+      scanner.setParameter("extension", ".tld");
+      scanner.setParameter("ignore", "META-INF/MANIFEST.MF");
+      scanner.setParameter("includeJar", "taglibs-standard-*.jar");
+      scanner.setParameter("excludeJar", "*");
+
+      List<String> expected = Arrays.asList(
+        "/META-INF/TestTag.tld",
+        "/META-INF/c.tld",
+        "/META-INF/c-1_0-rt.tld",
+        "/META-INF/c-1_1.tld",
+        "/META-INF/fmt-1_0-rt.tld",
+        "/META-INF/fmt.tld",
+        "/META-INF/fn.tld",
+        "/META-INF/permittedTaglibs.tld",
+        "/META-INF/scriptfree.tld",
+        "/META-INF/sql-1_0-rt.tld",
+        "/META-INF/sql.tld",
+        "/META-INF/x-1_0-rt.tld",
+        "/META-INF/x.tld"
+      );
+
+      List<String> sources = new ArrayList<>();
+      scanner.scan().forEachRemaining(e -> {
+        sources.add(e.getSystemID());
+      });
+
+      Collections.sort(sources);
+      Collections.sort(expected);
+      assertIterableEquals(expected, sources);
+  }
+
+  @Test
+  public void testScanExcludeJar() {
+      scanner.setParameter("root", "META-INF/");
+      scanner.setParameter("extension", ".mld");
+      scanner.setParameter("extension", ".tld");
+      scanner.setParameter("ignore", "META-INF/MANIFEST.MF");
+      scanner.setParameter("excludeJar", "*");
+
+      List<String> expected = Arrays.asList(
+        "/META-INF/TestTag.tld"
+      );
+
+      List<String> sources = new ArrayList<>();
+      scanner.scan().forEachRemaining(e -> {
+        sources.add(e.getSystemID());
+      });
+
+      Collections.sort(sources);
+      Collections.sort(expected);
+      assertIterableEquals(expected, sources);
+  }
+
+  @Test
+  public void returnsClassLoaderSourceDescriptor() {
+      scanner.setParameter("root", "META-INF/");
+      scanner.setParameter("extension", ".mld");
+      scanner.setParameter("extension", ".tld");
+      scanner.setParameter("ignore", "META-INF/MANIFEST.MF");
+      scanner.setParameter("excludeJar", "*");
+
+      List<String> expected = Arrays.asList(
+        "/META-INF/TestTag.tld"
+      );
+
+      List<String> sources = new ArrayList<>();
+      for (Iterator<SourceDescriptor> it = scanner.scan(); it.hasNext();) {
+          SourceDescriptor source = it.next();
+          sources.add(source.getSystemID());
+
+          assertInstanceOf(ApplicationFileSourceDescriptor.class, source);
+          assertNotNull(source.getInputStream());
+      }
+
+      Collections.sort(sources);
+      Collections.sort(expected);
+      assertIterableEquals(expected, sources);
+  }
+}


### PR DESCRIPTION
`ResourceScanner`はクラスパス内の指定パターンのファイルを列挙する。
列挙はJARファイル内のファイルも対象であるが、クラスパスとして多くのJARが指定されていると必要以上に時間がかかるため
含めるJARファイル名、除外するファイル名を明示的に指定できるようにする。

`ResourceScanner`が使用されているのは org.seasar.mayaa.provider.ServiceProvider 内の `libraryManager`エレメント内のみ。
`includeJar`および`excludeJar`パラメータ仕様を追加した。
*などのGLOBパターンが利用可能。

記述順に上からJARファイル名を評価し、最初に合致したパラメータ指定もって含めるか、含めないかを判断する。
いずれにも合致しない場合は含める。（既存の挙動と互換性がある）

#### taglibs-standard-*.jar のみを含め、それ以外のJARは対象外にする指定の例
```xml
<scanner class="org.seasar.mayaa.impl.builder.library.scanner.ResourceScanner">
    <parameter name="root" value="META-INF/"/>
    <parameter name="ignore" value="META-INF/MANIFEST.MF"/>
    <parameter name="extension" value=".mld"/>
    <parameter name="extension" value=".tld"/>
    <parameter name="includeJar" value="taglibs-standard-*.jar"/>
    <parameter name="excludeJar" value="*"/>
</scanner>
```

LibraryManagerでライブラリ読込み元のJARファイル名をログに出力し、JARファイルを特定しやすいようにした。
```
hh:mm:ss.sss [main] INFO  o.s.m.i.b.library.LibraryManagerImpl - loaded library - /META-INF/c-1_0-rt.tld - http://java.sun.com/jstl/core_rt from /taglibs-standard-impl-1.2.5.jar
```
