### PR TITLE
TemplateProcessor.notifyBeginRenderが実質的に呼ばれていない

### DIFF
--- a/src-api/org/seasar/mayaa/engine/Page.java
+++ b/src-api/org/seasar/mayaa/engine/Page.java
@@ -87,6 +87,7 @@ public interface Page
      * @param processor 通知を受けるプロセッサ。
      * @return true=登録成功 / false=既に登録済み
      */
+    @Deprecated
     boolean registBeginRenderNotifier(TemplateProcessor processor);
 
 }

--- a/src-api/org/seasar/mayaa/engine/processor/TemplateProcessor.java
+++ b/src-api/org/seasar/mayaa/engine/processor/TemplateProcessor.java
@@ -104,6 +104,7 @@ public interface TemplateProcessor extends ProcessorTreeWalker, Serializable {
      *
      * @param topLevelPage 描画トップレベルのページ。
      */
+    @Deprecated
     void notifyBeginRender(Page topLevelPage);
 
 }

--- a/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
@@ -18,8 +18,6 @@ package org.seasar.mayaa.impl.engine;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.collections.map.AbstractReferenceMap;
-import org.apache.commons.collections.map.ReferenceMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.cycle.script.CompiledScript;
@@ -188,7 +186,6 @@ public class PageImpl extends SpecificationImpl implements Page {
             setCurrentComponent(component);
             SpecificationUtil.execEvent(defaultSpec, CONST_IMPL.QM_BEFORE_RENDER_COMPONENT);
             try {
-                notifyBeginRender();
                 return RenderUtil.renderPage(true, this, null,
                         this, requestedSuffix, extension);
             } finally {
@@ -244,29 +241,10 @@ public class PageImpl extends SpecificationImpl implements Page {
         return templates[0].doTemplateRender(topLevelPage);
     }
 
-    protected Map<TemplateProcessor, Boolean> getBeginRenderListeners() {
-        synchronized(this) {
-            if (_beginRenderListeners == null) {
-                _beginRenderListeners = new ReferenceMap(
-                        AbstractReferenceMap.SOFT, AbstractReferenceMap.WEAK, true);
-            }
-        }
-        return _beginRenderListeners;
-    }
-
+    @Override
+    @Deprecated
     public boolean registBeginRenderNotifier(TemplateProcessor processor) {
-        boolean result =
-            getBeginRenderListeners().containsKey(processor) == false;
-        if (result == false) {
-            getBeginRenderListeners().put(processor, Boolean.TRUE);
-        }
-        return result;
-    }
-
-    protected void notifyBeginRender() {
-        for (TemplateProcessor listener : getBeginRenderListeners().keySet()) {
-            listener.notifyBeginRender(this);
-        }
+        throw new UnsupportedOperationException();
     }
 
     /*

--- a/src-impl/org/seasar/mayaa/impl/engine/processor/ElementProcessor.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/processor/ElementProcessor.java
@@ -92,9 +92,6 @@ public class ElementProcessor extends AbstractAttributableProcessor
                 new Object[] { getOriginalNode() });
     }
 
-    public void notifyBeginRender(Page topLevelPage) {
-        CycleUtil.clearGlobalVariable(RENDERED_NS_STACK_KEY);
-    }
 
     @SuppressWarnings("unchecked")
     protected Stack<List<PrefixMapping>> getRenderedNS() {
@@ -451,9 +448,6 @@ public class ElementProcessor extends AbstractAttributableProcessor
     }
 
     public ProcessStatus processStart(Page topLevelPage) {
-        if (topLevelPage != null) {
-            topLevelPage.registBeginRenderNotifier(this);
-        }
         renderInit();
         return super.processStart(topLevelPage);
     }

--- a/src-impl/org/seasar/mayaa/impl/engine/processor/JspProcessor.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/processor/JspProcessor.java
@@ -247,7 +247,6 @@ public class JspProcessor extends TemplateProcessorSupport
         if (_tagClass == null) {
             throw new IllegalStateException();
         }
-        topLevelPage.registBeginRenderNotifier(this);
         clearLoadedTag();
         Tag customTag = getLoadedTag();
 
@@ -404,10 +403,6 @@ public class JspProcessor extends TemplateProcessorSupport
                 popNestedVariables();
             }
         }
-    }
-
-    public void notifyBeginRender(Page topLevelPage) {
-        CycleUtil.clearLocalVariable(STOCK_VARIABLES_KEY, this);
     }
 
     @SuppressWarnings("unchecked")

--- a/src-impl/org/seasar/mayaa/impl/engine/processor/TemplateProcessorSupport.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/processor/TemplateProcessorSupport.java
@@ -231,6 +231,8 @@ public class TemplateProcessorSupport
         return new ProcessorTreeWalker[] { this };
     }
 
+    @Override
+    @Deprecated
     public void notifyBeginRender(Page topLevelPage) {
         // no operation
     }


### PR DESCRIPTION
Fixes #95 の方針とし、 interface定義自体は @deprecated として残しつつ、実装は空にする。
