### PR TITLE
[mayaa-user:1087] 独自プロセッサーを使うとエラーが発生する場合がある

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/engine/processor/ElementProcessor.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/processor/ElementProcessor.java
@@ -150,6 +150,10 @@ public class ElementProcessor extends AbstractAttributableProcessor
         return String.class;
     }
 
+    public Class<?> getInformalExpectedClass() {
+        return String.class;
+    }
+
     protected void resolvePrefix(PrefixAwareName name, Namespace currentNS) {
         if (name == null) {
             throw new IllegalArgumentException();

--- a/src/test/resources/it-case/engine/script/expected.html
+++ b/src/test/resources/it-case/engine/script/expected.html
@@ -25,7 +25,11 @@
 <span class="script5"></span>
 <span class="script6">6</span>
 <span class="script7">7</span>
-<span class="script8">8</span>
+<span data-value="8" class="script8">8</span>
+<!--  -->
+<span class="script9" data-value="9">9</span>
+<!--  -->
+<span class="script10" data-value="10">10</span>
 
 <dl id="numberList1">
 <dt id="numberList1numberKey0">10</dt><dd id="numberList1numberValue0">foo_b</dd>

--- a/src/test/resources/it-case/engine/script/target.html
+++ b/src/test/resources/it-case/engine/script/target.html
@@ -25,7 +25,11 @@
 <span class="script5">${ null }</span>
 <span class="script6">${ six }</span>
 <span class="script7">${ seven }</span>
-<span class="script8">${ eight }</span>
+<span class="script8" data-value="${ eight }">${ eight }</span>
+<!-- ${ var nine = 9; } -->
+<span class="script${nine}" data-value="${ nine }">${ nine }</span>
+<!-- ${ var ten = 9; ten++; ""} -->
+<span class="script${ten}" data-value="${ ten }">${ ten }</span>
 
 <dl id="numberList1">
 <dt id="numberKey">1</dt><dd id="numberValue">2</dd>


### PR DESCRIPTION
Fixes #13

下記のようにInformalPropertyの属性値として埋め込まれている場合に変数の文字列化に影響があった。
`ElementProcessor.getInformalExpectedClass()` を明示的に実装し、文字列を指定することで解決。

HTMLソース
```html
<!-- ${ var nine = 9; } -->
<span class="script${nine}" data-value="${ nine }">${ nine }</span>
<!-- ${ var ten = 9; ten++; ""} -->
<span class="script${ten}" data-value="${ ten }">${ ten }</span>
```

Mayaa生成後（問題解消前）
```html
<!--  -->
<span class="script9" data-value="9">9</span>
<!--  -->
<span class="script10.0" data-value="10.0">10</span>
```

Mayaa生成後（問題解消後）
```html
<!--  -->
<span class="script9" data-value="9">9</span>
<!--  -->
<span class="script10" data-value="10">10</span>
```
