### PR TITLE
Selenideをアップデート

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
     <dependency>
         <groupId>com.codeborne</groupId>
         <artifactId>selenide</artifactId>
-        <version>5.1.0</version>
+        <version>6.14.1</version>
         <scope>test</scope>
     </dependency>
   </dependencies> 


### PR DESCRIPTION
Accept-Languageが送られないことでfmt:formatNumberがpatternを処理せず integration-testしてしまうため。