### PR TITLE
ライブラリファイルのスキャンおよびServiceProviderファイル読み込みのログを出力

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/DefaultSourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/DefaultSourceScanner.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.builder.library.scanner.SourceScanner;
 import org.seasar.mayaa.impl.ParameterAwareImpl;
 import org.seasar.mayaa.impl.engine.processor.TemplateProcessorSupport;
@@ -30,6 +32,7 @@ import org.seasar.mayaa.source.SourceDescriptor;
  */
 public class DefaultSourceScanner extends ParameterAwareImpl
         implements SourceScanner {
+    private static final Log LOG = LogFactory.getLog(DefaultSourceScanner.class.getName());
 
     private static final long serialVersionUID = 690422240376318319L;
 
@@ -45,6 +48,7 @@ public class DefaultSourceScanner extends ParameterAwareImpl
     }
 
     public Iterator<SourceDescriptor> scan() {
+        LOG.debug("SCANNING for mayaa.mld");
         return _sources.iterator();
     }
 

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/FolderSourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/FolderSourceScanner.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.builder.library.scanner.SourceScanner;
 import org.seasar.mayaa.cycle.scope.ApplicationScope;
 import org.seasar.mayaa.impl.IllegalParameterValueException;
@@ -40,6 +42,8 @@ import org.seasar.mayaa.source.SourceDescriptor;
  */
 public class FolderSourceScanner extends ParameterAwareImpl
         implements SourceScanner {
+
+    private static final Log LOG = LogFactory.getLog(FolderSourceScanner.class.getName());
 
     private static final long serialVersionUID = 2888604805693825909L;
 
@@ -75,6 +79,7 @@ public class FolderSourceScanner extends ParameterAwareImpl
     }
 
     public Iterator<SourceDescriptor> scan() {
+        LOG.debug("SCANNING " + getFolder());
         ApplicationScope appScope = null;
         if (_source == null) {
             if (_absolute) {
@@ -126,9 +131,11 @@ public class FolderSourceScanner extends ParameterAwareImpl
                 }
                 for (int i = 0; i < _acceptableExtensions.length; i++) {
                     if (pathName.getName().endsWith(_acceptableExtensions[i])) {
+                        LOG.debug("READING " + pathName);
                         return true;
                     }
                 }
+                LOG.debug("SKIP    " + pathName.getAbsolutePath());
                 return false;
             }
         };

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/MetaInfSourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/MetaInfSourceScanner.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.seasar.mayaa.builder.library.scanner.SourceScanner;
 import org.seasar.mayaa.impl.IllegalParameterValueException;
 import org.seasar.mayaa.impl.ParameterAwareImpl;
@@ -31,6 +33,8 @@ import org.seasar.mayaa.source.SourceDescriptor;
  */
 public class MetaInfSourceScanner extends ParameterAwareImpl
         implements SourceScanner {
+    
+    private static final Log LOG = LogFactory.getLog(MetaInfSourceScanner.class.getName());
 
     private static final long serialVersionUID = -7285416169718204350L;
 
@@ -75,13 +79,17 @@ public class MetaInfSourceScanner extends ParameterAwareImpl
      */
     @SuppressWarnings("unchecked")
     public Iterator<SourceDescriptor> scan() {
+        LOG.debug("SCANNING META-INF");
+
         initJarScanOptions();
         IteratorIterator itit = new IteratorIterator();
         for (Iterator<SourceDescriptor> it = _folderScanner.scan(); it.hasNext(); ) {
             SourceDescriptor descriptor = it.next();
             if (isIgnored(descriptor)) {
+                LOG.debug("SKIP    " + descriptor.getSystemID());
                 continue;
             }
+                LOG.debug("READING " + descriptor.getSystemID());
 
             JarSourceScanner scanner = new JarSourceScanner();
             scanner.setDescriptor(descriptor);

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/ResourceScanner.java
@@ -54,6 +54,8 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
 
     @SuppressWarnings("unchecked")
     public Iterator<SourceDescriptor> scan() {
+        LOG.debug("SCANNING in Classpath");
+
         // classpath要素を分解してスキャン対象を決定。
         // includeJar, excludeJarの指定が存在しない場合は互換性のため全てのJarを含める
         String[] pathArray = System.getProperty("java.class.path", ".").split(File.pathSeparator);
@@ -63,10 +65,14 @@ public class ResourceScanner extends ParameterAwareImpl implements SourceScanner
                 continue;
             }
             if (file.isDirectory()) {
+                LOG.debug("READING " + file.getAbsolutePath());
                 _classPath.add(path);
             } else if (file.getName().endsWith(".jar")) {
                 if (_jarMatcher.matches(file.toPath().getFileName())) {
+                    LOG.debug("READING " + file.getAbsolutePath());
                     _jars.add(path);
+                } else {
+                    LOG.debug("SKIP    " + file.getAbsolutePath());
                 }
             }
         }

--- a/src-impl/org/seasar/mayaa/impl/builder/library/scanner/WebXMLTaglibSourceScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/library/scanner/WebXMLTaglibSourceScanner.java
@@ -77,6 +77,7 @@ public class WebXMLTaglibSourceScanner extends NonSerializableParameterAwareImpl
     }
 
     public Iterator<SourceDescriptor> scan() {
+        LOG.debug("SCANNING in web.xml");
         SourceDescriptor source = FactoryFactory.getBootstrapSource(
                 ApplicationSourceDescriptor.WEB_INF, "web.xml");
         return new TaglibLocationIterator(scanWebXml(source));

--- a/src/test/resources/jul.properties
+++ b/src/test/resources/jul.properties
@@ -1,9 +1,11 @@
-#handlers= java.util.logging.FileHandler,java.util.logging.ConsoleHandler
-handlers= java.util.logging.ConsoleHandler
-.level = SEVERE
+handlers=java.util.logging.ConsoleHandler
+.handlers=java.util.logging.ConsoleHandler
+.level=INFO
+org.seasar.mayaa.level=INFO
+org.seasar.mayaa.impl.builder.level=FINE
+org.seasar.mayaa.functional.TestingMockServletContext.level=SEVERE
 
-#java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
 # %1:date/time %2:className and methodName %3logName %4:level %5:message %6:errormessage
-java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL|%4$s|%2$s|%5$s%n
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s [%2$s] %5$s%6$s%n

--- a/test-war/src/main/resources/jboss-logging.properties
+++ b/test-war/src/main/resources/jboss-logging.properties
@@ -1,0 +1,29 @@
+# JBoss Logging configuration for JBoss/Wildfly
+loggers=org.seasar.mayaa,org.seasar.mayaa.impl.builder.library
+# Root logger configuration
+logger.level=INFO
+logger.org.seasar.mayaa.level=FINE
+logger.org.seasar.mayaa.impl.builder.library.level=INFO
+
+
+# HANDLERS
+logger.handlers=CONSOLE
+ 
+# A handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.level=ALL
+handler.CONSOLE.formatter=COLOR-PATTERN
+handler.CONSOLE.properties=autoFlush,target,enabled
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.target=SYSTEM_OUT
+handler.CONSOLE.enabled=true
+ 
+# The formatter to use
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.constructorProperties=pattern
+formatter.PATTERN.pattern=%d %-5p %c: %m%n
+
+formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.COLOR-PATTERN.properties=pattern
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] %s%e%n

--- a/test-war/src/main/resources/logging.properties
+++ b/test-war/src/main/resources/logging.properties
@@ -1,0 +1,7 @@
+# JUL configuration
+.handlers=java.util.logging.ConsoleHandler
+.level=INFO
+
+org.apache.commons.beanutils.level=SEVERE
+org.seasar.mayaa.level=INFO
+org.seasar.mayaa.impl.builder.library.level=FINE

--- a/test-war/src/main/webapp/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
+++ b/test-war/src/main/webapp/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE provider
+    PUBLIC "-//The Seasar Foundation//DTD Mayaa Provider 1.0//EN"
+    "http://mayaa.seasar.org/dtd/mayaa-provider_1_0.dtd">
+<provider class="org.seasar.mayaa.impl.provider.ServiceProviderImpl">
+
+    <engine class="org.seasar.mayaa.impl.engine.EngineImpl">
+        <errorHandler class="org.seasar.mayaa.impl.engine.error.TemplateErrorHandler">
+            <parameter name="folder" value="/"/>
+            <parameter name="extension" value="html"/>
+            <parameter name="omitHandlerPageNotExist" value="true" /><!-- since 1.2.1 -->
+            <parameter name="omitStackTraceToLogger" value="true" /><!-- since 1.2.1 -->
+        </errorHandler>
+        <parameter name="pageClass" value="org.seasar.mayaa.impl.engine.PageImpl"/>
+        <parameter name="templateClass" value="org.seasar.mayaa.impl.engine.TemplateImpl"/>
+        <parameter name="defaultSpecification" value="/default.mayaa"/>
+        <parameter name="checkTimestamp" value="true"/>
+        <parameter name="suffixSeparator" value="$"/>
+        <parameter name="requestedSuffixEnabled" value="false" />
+        <parameter name="welcomeFileName" value="index.html"/>
+        <parameter name="requestCharacterEncoding" value="UTF-8"/>
+        <parameter name="pageSerialize" value="false"/>
+        <parameter name="surviveLimit" value="5"/>
+        <parameter name="autoBuild" value="false"/>
+        <parameter name="autoBuild.repeat" value="false"/>
+        <parameter name="autoBuild.wait" value="60"/><!-- seconds -->
+        <parameter name="autoBuild.fileNameFilters" value=".html"/><!-- .html;^(sample|howto).+\.htm$ -->
+        <parameter name="autoBuild.renderMate" value="false"/>
+        <parameter name="autoBuild.contextPath" value="/"/>
+        <parameter name="forwardLimit" value="10"/>
+        <parameter name="noCacheValue" value="no-cache"/><!-- since 1.1.27, for firefox "no-cache, no-store" -->
+        <parameter name="dumpEnabled" value="false" />
+        <parameter name="convertCharset" value="true"/><!-- since 1.1.12 -->
+    </engine>
+
+    <scriptEnvironment class="org.seasar.mayaa.impl.cycle.script.rhino.ScriptEnvironmentImpl">
+        <scope class="org.seasar.mayaa.impl.cycle.scope.ParamScope"/>
+        <scope class="org.seasar.mayaa.impl.cycle.scope.HeaderScope"/>
+        <scope class="org.seasar.mayaa.impl.cycle.scope.BindingScope"/>
+
+        <!-- "_" = current - page - request - session - application -->
+        <scope class="org.seasar.mayaa.impl.cycle.script.rhino.WalkStandardScope"/>
+        <!-- extension: java.lang.System.getProperty()
+        <scope class="org.seasar.mayaa.impl.cycle.scope.EnvScope"/>
+        -->
+        <parameter name="wrapFactory" value="org.seasar.mayaa.impl.cycle.script.rhino.WrapFactoryImpl"/>
+        <parameter name="cacheSize" value="256"/><!-- since 1.2-SNAPSHOT -->
+    </scriptEnvironment>
+
+    <specificationBuilder class="org.seasar.mayaa.impl.builder.SpecificationBuilderImpl">
+        <parameter name="outputMayaaWhitespace" value="false"/>
+    </specificationBuilder>
+
+    <libraryManager class="org.seasar.mayaa.impl.builder.library.LibraryManagerImpl">
+        <converter name="ProcessorProperty" class="org.seasar.mayaa.impl.builder.library.converter.ProcessorPropertyConverter"/>
+        <converter name="PrefixAwareName" class="org.seasar.mayaa.impl.builder.library.converter.PrefixAwareNameConverter"/>
+
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.FolderSourceScanner">
+            <parameter name="folder" value="/WEB-INF"/>
+            <parameter name="recursive" value="true"/>
+            <parameter name="extension" value=".tld"/>
+            <parameter name="extension" value=".mld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.MetaInfSourceScanner">
+            <parameter name="folder" value="/WEB-INF/lib"/>
+            <parameter name="extension" value=".jar"/>
+            <parameter name="ignore" value="commons-beanutils-"/>
+            <parameter name="ignore" value="commons-collections-"/>
+            <parameter name="ignore" value="commons-logging-"/>
+            <parameter name="ignore" value="nekohtml-"/>
+            <parameter name="ignore" value="jaxen-"/>
+            <parameter name="ignore" value="xml-apis-"/>
+            <parameter name="ignore" value="xercesImpl-"/>
+            <parameter name="ignore" value="rhino-"/>
+            <parameter name="jar.ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="jar.ignore" value="META-INF/scriptfree"/>
+            <parameter name="jar.extension" value=".mld"/>
+            <parameter name="jar.extension" value=".tld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.ResourceScanner">
+            <parameter name="root" value="META-INF/"/>
+            <parameter name="ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="extension" value=".mld"/>
+            <parameter name="extension" value=".tld"/>
+            <parameter name="includeJar" value="taglibs-standard-impl-*.jar"/>
+            <parameter name="excludeJar" value="*"/>
+        </scanner>
+
+        <!-- after scan jars -->
+        <!-- <scanner class="org.seasar.mayaa.impl.builder.library.scanner.WebXMLTaglibSourceScanner"/> -->
+
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.DefaultSourceScanner"/>
+        <builder class="org.seasar.mayaa.impl.builder.library.MLDDefinitionBuilder"/>
+        <builder class="org.seasar.mayaa.impl.builder.library.TLDDefinitionBuilder"/>
+    </libraryManager>
+
+    <templateBuilder class="org.seasar.mayaa.impl.builder.TemplateBuilderImpl">
+        <resolver class="org.seasar.mayaa.impl.builder.injection.MetaValuesSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.ReplaceSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.RenderedSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InsertSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InjectAttributeInjectionResolver"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.EqualsIDInjectionResolver">
+            <parameter name="reportUnresolvedID" value="true"/>
+            <parameter name="reportDuplicatedID" value="true"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/TR/html4}id"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/1999/xhtml}id"/>
+        </resolver>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.XPathMatchesInjectionResolver"/>
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="optimize" value="true"/>
+        <parameter name="defaultCharset" value="UTF-8"/><!-- since 1.1.22 -->
+        <parameter name="replaceSSIInclude" value="true"/><!-- since 1.1.25 -->
+        <parameter name="balanceTag" value="true"/><!-- since 1.1.29 -->
+        <parameter name="useNewParser" value="true"/><!-- since 1.2.1 -->
+    </templateBuilder>
+
+    <pathAdjuster class="org.seasar.mayaa.impl.builder.PathAdjusterImpl">
+        <parameter name="enabled" value="true"/>
+        <parameter name="force" value="false"/><!-- since 1.1.13 -->
+    </pathAdjuster>
+
+    <templateAttributeReader class="org.seasar.mayaa.impl.builder.library.TemplateAttributeReaderImpl">
+        <!-- example
+        <ignoreAttribute
+                qName="{http://struts.apache.org/tags-html}errors"
+                attribute="id"/>
+        <aliasAttribute
+                qName="{http://struts.apache.org/tags-html}*"
+                attribute="styleId"
+                templateAttribute="id" />
+        -->
+        <ignoreAttribute
+                qName="{http://java.sun.com/jsp/jstl/core}out" attribute="escapeXml"/>
+        <aliasAttribute
+                qName="{http://java.sun.com/jsp/jstl/fmt}formatN*" attribute="patt*"
+                templateAttribute="formatPattern" />
+        <aliasAttribute
+                qName="{http://mayaa.seasar.org/test/mayaa-test}simpleTest*"
+                attribute="styleClass" templateAttribute="class" />
+        <parameter name="enabled" value="true"/>
+    </templateAttributeReader>
+
+    <parentSpecificationResolver class="org.seasar.mayaa.impl.engine.specification.ParentSpecificationResolverImpl">
+    </parentSpecificationResolver>
+
+</provider>


### PR DESCRIPTION
ライブラリファイルのスキャンおよびServiceProviderファイル読み込みのログを出力しました。
必要以上に読み込み量が多くなっていないかを確認できるようにするためです。
ログレベルは DEBUG にしています。

ロガー名は org.seasar.mayaa.impl.builder.library から始まりますので
JULの場合で個別に出力するとき下記のようにしてみてください

logging.properties
```
org.seasar.mayaa.level=INFO
org.seasar.mayaa.impl.builder.library.level=FINE
```
