### PR TITLE
新パーサーでパース時の警告をNodeHanderまで伝達する

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/SpecificationNodeHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/SpecificationNodeHandler.java
@@ -421,22 +421,22 @@ public abstract class SpecificationNodeHandler
 
     private String exceptionMessage(SAXParseException e) {
         return
-            "The problem occurred during Perse. " +
-            _specification.getSystemID() +
-            ((e.getMessage() != null)?" - " + e.getMessage(): "");
+            "The problem occurred during parse. " +
+            _specification.getSystemID() + "[" + e.getLineNumber() + ":" + e.getColumnNumber() + "]" +
+            ((e.getMessage() != null) ? " - " + e.getMessage(): "");
     }
 
     @Override
     public void warning(SAXParseException e) {
         if (LOG.isWarnEnabled()) {
-            LOG.warn(exceptionMessage(e), e);
+            LOG.warn(exceptionMessage(e));
         }
     }
 
     @Override
     public void fatalError(SAXParseException e) {
         if (LOG.isFatalEnabled()) {
-            LOG.fatal(exceptionMessage(e), e);
+            LOG.fatal(exceptionMessage(e));
         }
         throw new RuntimeException(exceptionMessage(e), e);
     }
@@ -444,7 +444,7 @@ public abstract class SpecificationNodeHandler
     @Override
     public void error(SAXParseException e) {
         if (LOG.isErrorEnabled()) {
-            LOG.error(exceptionMessage(e), e);
+            LOG.error(exceptionMessage(e));
         }
         throw new RuntimeException(exceptionMessage(e), e);
     }

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HTMLErrorReporter.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HTMLErrorReporter.java
@@ -1,0 +1,55 @@
+package org.seasar.mayaa.impl.builder.parser;
+
+import java.util.Arrays;
+
+import org.apache.xerces.impl.XMLErrorReporter;
+import org.apache.xerces.xni.XNIException;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+public abstract class HTMLErrorReporter extends XMLErrorReporter{
+  ErrorHandler _errorHandler;
+  HTMLErrorReporter(ErrorHandler errorHandler) {
+    _errorHandler = errorHandler;
+  }
+
+  public void setErrorHandler(ErrorHandler errorHandler) {
+    _errorHandler = errorHandler;
+  }
+
+  abstract void reportError(HtmlLocation location, ParseError error, Object[] args);
+}
+
+class DefaultHTMLErrorHandler extends HTMLErrorReporter {
+
+  DefaultHTMLErrorHandler(ErrorHandler errorHandler) {
+    super(errorHandler);
+  }
+
+  @Override
+  void reportError(HtmlLocation location, ParseError error, Object[] args) {
+    if (_errorHandler != null) {
+      try {
+        switch (error.severity) {
+        case ParseError.SEVERITY_FATAL_ERROR:
+          _errorHandler.fatalError(createSAXException(location, error, args));
+          break;
+        case ParseError.SEVERITY_ERROR:
+          _errorHandler.error(createSAXException(location, error, args));
+          break;
+        case ParseError.SEVERITY_WARNING:
+          _errorHandler.warning(createSAXException(location, error, args));
+          break;
+        }
+      } catch (SAXException e) {
+        throw new XNIException(e);
+      }
+    }
+  }
+
+  private SAXParseException createSAXException(HtmlLocation location, ParseError error, Object[] args) {
+    return new SAXParseException(error.name() + " (args: " + Arrays.toString(args) + ") " + location.getTextAroundCurrent(), location.getPublicId(), location.getSystemId(), location.getLineNumber(), location.getColumnNumber());
+  }
+
+}

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
@@ -17,11 +17,8 @@ package org.seasar.mayaa.impl.builder.parser;
 
 import java.io.IOException;
 
-import org.apache.xerces.impl.Constants;
-import org.apache.xerces.impl.XMLErrorReporter;
 import org.apache.xerces.parsers.BasicParserConfiguration;
 import org.apache.xerces.xni.XMLDocumentHandler;
-import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLInputSource;
 import org.seasar.mayaa.impl.CONST_IMPL;
 import org.seasar.mayaa.impl.util.xml.AdditionalSAXParser;
@@ -36,31 +33,31 @@ public class HtmlTemplateParser extends AdditionalSAXParser implements CONST_IMP
     public static String FEATURE_INSERT_IMPLIED_ELEMENT = HtmlStandardScanner.FEATURE_INSERT_IMPLIED_ELEMENT;
 
     static class ParserConfiguration extends BasicParserConfiguration {
-        protected static final String ERROR_REPORTER = Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_REPORTER_PROPERTY;
 
         HtmlStandardScanner scanner = new HtmlStandardScanner();
 
         ParserConfiguration() {
-            addRecognizedProperties(new String[] { ERROR_REPORTER });
-            XMLErrorReporter errorReporter = new XMLErrorReporter();
-            setProperty(ERROR_REPORTER, errorReporter);
-            addComponent(errorReporter);
             addComponent(scanner);
         }
 
         @Override
-        public void parse(XMLInputSource inputSource) throws XNIException, IOException {
-            scanner.reset(this);
-            XMLDocumentHandler documentHandler = getDocumentHandler();
-            scanner.setDocumentHandler(documentHandler);
-            scanner.setInputSource(inputSource);
-            scanner.scanDocument(true);
+        public void parse(XMLInputSource inputSource) throws IOException {
+            try {
+                scanner.reset(this);
+                XMLDocumentHandler documentHandler = getDocumentHandler();
+                scanner.setDocumentHandler(documentHandler);
+                scanner.setInputSource(inputSource);
+                scanner.scanDocument(true);    
+            } catch (IOException | RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw e;
+            } finally {
+                scanner.setInputSource(null);
+            }
         }
     }
 
-    /**
-     * @param balanceTag タグのバランスを修正するか。基本的にtrue。falseにする場合は必ずテンプレートのタグのバランスを取ること。
-     */
     public HtmlTemplateParser() {
         super(new ParserConfiguration());
         // super(isHTML ? new TemplateParserConfiguration(): new StandardParserConfiguration());

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/ParseError.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/ParseError.java
@@ -1,0 +1,78 @@
+package org.seasar.mayaa.impl.builder.parser;
+
+import org.apache.xerces.impl.XMLErrorReporter;
+
+/**
+ * HtmlStadaardScannerで発生するエラーの種類を定義する列挙型。
+ * 各エラーの詳細はWHATWGのHTML Living Standardを参照。
+ * それぞれのエラーは、エラーの重要度を示すshort型のseverityフィールドを持つ。
+ * エラー自体でパースを中断するべきかどうかは、severityフィールドの値によって決まる。
+ * 
+ * <ul>
+ * <li>FATAL_ERRORの場合は中断する。</li>
+ * <li>ERRORの場合は中断する。</li>
+ * <li>WARNINGの場合は中断しない。</li>
+ * </ul>
+ */
+enum ParseError {
+    PARSE_ERROR,
+    UNEXPECTED_NULL_CHARACTER,
+    // TAG
+    EOF_BEFORE_TAG_NAME,
+    EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT,
+    EOF_IN_TAG,
+    INVALID_FIRST_CHARACTER_OF_TAG_NAME,
+    MISSING_ATTRIBUTE_VALUE,
+    MISSING_END_TAG_NAME,
+    UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME,
+    UNEXPECTED_SOLIDUS_IN_TAG,
+    // ATTRIBUTE
+    DUPLICATE_ATTRIBUTE,
+    MISSING_WHITESPACE_BETWEEN_ATTRIBUTES,
+    UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME,
+    UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE,
+    UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME,
+    // CDATA
+    CDATA_IN_HTML_CONTENT,
+    EOF_IN_CDATA,
+    // COMMENTES
+    INCORRECTLY_OPENED_COMMENT,
+    ABRUPT_CLOSING_OF_EMPTY_COMMENT,
+    NESTED_COMMENT,
+    INCORRECTLY_CLOSED_COMMENT,
+    EOF_IN_COMMENT,
+    // doctype
+    EOF_IN_DOCTYPE,
+    MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD,
+    MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER,
+    MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS,
+    ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER,
+    MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME,
+    MISSING_DOCTYPE_NAME,
+    INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME,
+    MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD,
+    MISSING_DOCTYPE_PUBLIC_IDENTIFIER,
+    MISSING_DOCTYPE_SYSTEM_IDENTIFIER,
+    MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER,
+    ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER,
+    UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER;
+
+    static final short SEVERITY_ERROR = XMLErrorReporter.SEVERITY_ERROR;
+    static final short SEVERITY_FATAL_ERROR = XMLErrorReporter.SEVERITY_FATAL_ERROR;
+    static final short SEVERITY_WARNING = XMLErrorReporter.SEVERITY_WARNING;
+
+    short severity;
+
+    /** デフォルトのエラーの重要度はWARNING */
+    ParseError() {
+        this.severity = SEVERITY_WARNING;
+    }
+
+    ParseError(short severity) {
+        this.severity = severity;
+    }
+
+    public String messageId() {
+        return this.name().replace('_', '-');
+    }
+}


### PR DESCRIPTION
HtmlStandardScannerにカスタムErrorReporterを導入し、パースエラーの報告と管理を強化します。
これにより、パース処理中のエラーをより詳細かつ柔軟に扱えるようになります。

NodeHandlerで受け取ったパースのエラー情報はリスト化してTemplateに保持させて、ページ処理の過程で読み出せるようにプロセッサーを定義することも考えられる。

現時点ではロガーでWARNレベルで出力されるのみ。