### PR TITLE
Mayaaで名前空間を扱うためHTMLエレメント名として妥当でないものもパースできる

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
@@ -1607,6 +1607,7 @@ class HtmlTokenizer {
                             handler.reportError("invalid-first-character-of-tag-name", null);
                             tokenizeState = TokenizeState.Data;
                             appendTextNode('<');
+                            pushBack();
                         }
                         break;
 
@@ -1628,7 +1629,7 @@ class HtmlTokenizer {
                         } else {
                             handler.reportError("invalid-first-character-of-tag-name", null);
                             tokenizeState = TokenizeState.BogusComment;
-                            appendTextNode('<');
+                            pushBack();
                         }
                         break;
 


### PR DESCRIPTION
エレメント名の先頭文字として許されない文字がある場合は次の開始タグまではテキストノードとして扱われますが、閉じタグの先頭文字として許されない文字の場合はHTMLコメントとして出力されます。ブラウザでの解釈も同じです。

ただし、NekoHtmlの場合は不正な閉じタグのHTMLコメント出力はされません。
