### PR TITLE
perf: Mayaa並行性の最適化と正しさ改善

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/cycle/CycleFactoryImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/cycle/CycleFactoryImpl.java
@@ -49,7 +49,7 @@ public class CycleFactoryImpl
     private Class<?> _serviceClass;
     private CycleLocalVariables _localVariables = new CycleLocalVariablesImpl();
 
-    protected synchronized void initCurrentStrage() {
+    protected void initCurrentStrage() {
         if (_currentCycle.get() == null) {
             _currentCycle.set(new Object[1]);
         }

--- a/src-impl/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/cycle/script/rhino/ScriptEnvironmentImpl.java
@@ -49,7 +49,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
  */
 public class ScriptEnvironmentImpl extends AbstractScriptEnvironment {
 
-    private static Scriptable _standardObjects;
+    private static volatile Scriptable _standardObjects;
     private static final Cache<String, CompiledScript> _scriptCache = Caffeine.newBuilder()
         .maximumSize(10_000)
         .recordStats()
@@ -124,20 +124,43 @@ public class ScriptEnvironmentImpl extends AbstractScriptEnvironment {
     }
 
     protected static Scriptable getStandardObjects() {
-        if (_standardObjects == null) {
-            Context cx = Context.enter();
-            try {
-                _standardObjects = cx.initStandardObjects(null, true);
-                if (CONSTRAINT_GLOBAL_PROPERTY_DEFINE) {
-                	ScriptableObject scope = (ScriptableObject)_standardObjects;
-                	scope.defineProperty("__global__", scope,
-                			ScriptableObject.READONLY | ScriptableObject.DONTENUM);
+        Scriptable result = _standardObjects;
+        if (result == null) {
+            synchronized (ScriptEnvironmentImpl.class) {
+                result = _standardObjects;
+                if (result == null) {
+                    Context cx = Context.enter();
+                    try {
+                        result = cx.initStandardObjects(null, true);
+                        if (CONSTRAINT_GLOBAL_PROPERTY_DEFINE) {
+                            ScriptableObject scope = (ScriptableObject) result;
+                            scope.defineProperty("__global__", scope,
+                                    ScriptableObject.READONLY | ScriptableObject.DONTENUM);
+                        }
+                        _standardObjects = result; // volatile write: publish after core init
+                        // NativeJavaPackage の内部キャッシュを起動時に一度だけ pre-warm。
+                        // リクエストスレッドが java.lang.* へ初アクセスする際の synchronized 競合を低減する。
+                        // ウォームアップ失敗は致命的ではないので try-catch で保護する。
+                        try {
+                            Scriptable warmupScope = cx.newObject(result);
+                            warmupScope.setParentScope(result);
+                            cx.evaluateString(warmupScope,
+                                "java.lang.Object; java.lang.String; java.lang.System;"
+                                + " java.lang.Math; java.lang.Integer; java.lang.Long;"
+                                + " java.lang.Boolean; java.lang.Number; java.lang.Class;"
+                                + " java.lang.StringBuilder; java.lang.StringBuffer;"
+                                + " java.util.Date; java.util.ArrayList; java.util.HashMap;",
+                                "<warmup>", 1, null);
+                        } catch (Exception e) {
+                            // pre-warm はベストエフォートなので失敗しても無視する
+                        }
+                    } finally {
+                        Context.exit();
+                    }
                 }
-            } finally {
-                Context.exit();
             }
         }
-        return _standardObjects;
+        return result;
     }
 
     private static final String PARENT_SCRIPTABLE_KEY =

--- a/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
@@ -548,6 +548,12 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
     }
 
     public Template createTemplateInstance(final Page page, final String suffix, final String extension) {
+        final String templateId = getTemplateID(page, suffix, extension);
+        Specification cached = _specCache.getIfPresent(templateId);
+        if (cached != null) {
+            return (Template) cached;
+        }
+
         final SpecificationGenerator generator = new SpecificationGenerator() {
             public Class<?> getInstantiator(SourceDescriptor source) {
                 if (source.exists() == false) {
@@ -559,8 +565,15 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
                 ((Template) instance).initialize(page, suffix, extension);
             }
         };
-        final String templateId = getTemplateID(page, suffix, extension);
-        return (Template) createSpecificationInstance(templateId, true, generator);
+        Specification created = createSpecificationInstance(templateId, false, generator);
+        if (created == null) {
+            return null;
+        }
+        Specification existing = _specCache.asMap().putIfAbsent(templateId, created);
+        if (existing != null) {
+            return (Template) existing;
+        }
+        return (Template) created;
     }
 
     public String getTemplateID(final Page page, final String suffix, final String extension) {

--- a/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
@@ -137,17 +137,15 @@ public class PageImpl extends SpecificationImpl implements Page {
             throw new IllegalArgumentException();
         }
         Engine engine = ProviderUtil.getEngine();
-        synchronized (engine) {
-            String systemID = engine.getTemplateID(this, suffix, extension);
-            Template template = findTemplateFromCache(systemID);
-            if (template != null) {
-                if (template.getSource().exists()) {
-                    return template;
-                }
-                return null;
+        String systemID = engine.getTemplateID(this, suffix, extension);
+        Template template = findTemplateFromCache(systemID);
+        if (template != null) {
+            if (template.getSource().exists()) {
+                return template;
             }
-            return engine.createTemplateInstance(this, suffix, extension);
+            return null;
         }
+        return engine.createTemplateInstance(this, suffix, extension);
     }
 
     public Template getTemplate(String suffix, String extension) {

--- a/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
@@ -46,9 +46,10 @@ public class PageImpl extends SpecificationImpl implements Page {
     private static final String CURRENT_COMPONENT_KEY = "__currentComponent__";
 
     private String _pageName;
-    private transient Page _superPage;
-    private transient String _superSuffix;
-    private transient String _superExtension;
+    private transient volatile Page _superPage;
+    private transient volatile String _superSuffix;
+    private transient volatile String _superExtension;
+    private transient volatile boolean _superPrepared;
 
     private transient Map<TemplateProcessor, Boolean> _beginRenderListeners;
     private String _suffixScriptText;
@@ -65,17 +66,23 @@ public class PageImpl extends SpecificationImpl implements Page {
     }
 
     protected void prepareSuper() {
-        if (_superPage != null && _superPage.isDeprecated() == false) {
+        Page superPage = _superPage;
+        if (_superPrepared && (superPage == null || superPage.isDeprecated() == false)) {
             return;
         }
         synchronized (this) {
-            if (_superPage != null && _superPage.isDeprecated() == false) {
+            superPage = _superPage;
+            if (_superPrepared && (superPage == null || superPage.isDeprecated() == false)) {
                 return;
             }
             // TODO mayaa以外からも取得できるようにする
             String extendsPath =
                 SpecificationUtil.getMayaaAttributeValue(this, CONST_IMPL.QM_EXTENDS);
             if (StringUtil.isEmpty(extendsPath)) {
+                _superPage = null;
+                _superSuffix = null;
+                _superExtension = null;
+                _superPrepared = true;
                 return;
             }
             Engine engine = ProviderUtil.getEngine();
@@ -86,6 +93,7 @@ public class PageImpl extends SpecificationImpl implements Page {
                     StringUtil.adjustRelativePath(_pageName, pagePath[0]));
             _superSuffix = pagePath[1];
             _superExtension = pagePath[2];
+            _superPrepared = true;
         }
     }
 
@@ -252,7 +260,7 @@ public class PageImpl extends SpecificationImpl implements Page {
     @Override
     public int hashCode() {
         return Objects.hash(_beginRenderListeners, _pageName, _suffixScript, _suffixScriptText, _superExtension,
-                _superPage, _superSuffix);
+                _superPage, _superPrepared, _superSuffix);
     }
 
     /*
@@ -272,6 +280,7 @@ public class PageImpl extends SpecificationImpl implements Page {
                 && Objects.equals(_suffixScriptText, other._suffixScriptText)
                 && Objects.equals(_superExtension, other._superExtension)
                 && Objects.equals(_superPage, other._superPage)
+            && _superPrepared == other._superPrepared
                 && Objects.equals(_superSuffix, other._superSuffix)
                 && super.equals(other);
     }

--- a/src-impl/org/seasar/mayaa/impl/engine/processor/ComponentRenderer.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/processor/ComponentRenderer.java
@@ -22,7 +22,6 @@ import org.seasar.mayaa.engine.processor.ProcessStatus;
 import org.seasar.mayaa.engine.processor.ProcessorTreeWalker;
 import org.seasar.mayaa.engine.processor.TemplateProcessor;
 import org.seasar.mayaa.impl.engine.RenderUtil;
-import org.seasar.mayaa.impl.provider.ProviderUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
 
 /**
@@ -97,12 +96,10 @@ public class ComponentRenderer implements TemplateRenderer {
 
     protected DoRenderProcessor findDoRender(
             Template[] templates, String name) {
-        synchronized (ProviderUtil.getEngine()) {
-            for (int i = templates.length - 1; 0 <= i; i--) {
-                DoRenderProcessor doRender = findDoRender(templates[i], name);
-                if (doRender != null) {
-                    return doRender;
-                }
+        for (int i = templates.length - 1; 0 <= i; i--) {
+            DoRenderProcessor doRender = findDoRender(templates[i], name);
+            if (doRender != null) {
+                return doRender;
             }
         }
         return null;

--- a/src-impl/org/seasar/mayaa/impl/engine/specification/NamespaceImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/specification/NamespaceImpl.java
@@ -64,7 +64,7 @@ public class NamespaceImpl implements Namespace {
     private transient Set<PrefixMapping> _mappings;
     private transient PrefixMapping _defaultNamespaceMapping;
     private String _serializeKey;
-    private transient boolean _needDeserialize;
+    private transient volatile boolean _needDeserialize;
 
     public void setParentSpace(Namespace parent) {
         /*
@@ -341,8 +341,13 @@ public class NamespaceImpl implements Namespace {
     }
 
     protected void doDeserialize() {
-        if (_needDeserialize) {
-            _needDeserialize = false;
+        if (_needDeserialize == false) {
+            return;
+        }
+        synchronized (this) {
+            if (_needDeserialize == false) {
+                return;
+            }
 
             NamespaceImpl current = deserialize(getSerializeKey());
 
@@ -353,6 +358,7 @@ public class NamespaceImpl implements Namespace {
                     ; it.hasNext(); ) {
                 _mappings.add(it.next());
             }
+            _needDeserialize = false;
         }
     }
 

--- a/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationNodeImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationNodeImpl.java
@@ -50,7 +50,7 @@ public class SpecificationNodeImpl extends NamespaceImpl
     private int _sequenceID = -1;
     private String _id = null;
     private Map<QName, NodeAttribute> _attributes;
-    private NodeTreeWalkerImpl _delegateNodeTreeWalker;
+    private volatile NodeTreeWalkerImpl _delegateNodeTreeWalker;
     // for PrefixAwareName
     private QName _qName;
     private String _prefix;
@@ -65,15 +65,20 @@ public class SpecificationNodeImpl extends NamespaceImpl
     }
 
     protected NodeTreeWalker getNodeTreeWalker() {
-        if (_delegateNodeTreeWalker == null) {
+        NodeTreeWalkerImpl delegate = _delegateNodeTreeWalker;
+        if (delegate == null) {
             synchronized (this) {
-                _delegateNodeTreeWalker = new NodeTreeWalkerImpl();
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("_delegateNodeTreeWalker created.");
+                delegate = _delegateNodeTreeWalker;
+                if (delegate == null) {
+                    delegate = new NodeTreeWalkerImpl();
+                    _delegateNodeTreeWalker = delegate;
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("_delegateNodeTreeWalker created.");
+                    }
                 }
             }
         }
-        return _delegateNodeTreeWalker;
+        return delegate;
     }
 
     public String toString() {

--- a/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationUtil.java
@@ -24,12 +24,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import jakarta.servlet.ServletContext;
 
@@ -55,6 +54,9 @@ import org.seasar.mayaa.impl.engine.specification.serialize.NodeSerializeControl
 import org.seasar.mayaa.impl.engine.specification.serialize.ProcessorSerializeController;
 import org.seasar.mayaa.impl.provider.ProviderUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * Specificationに関わるユーティリティメソッドをまとめたクラスです。
@@ -229,18 +231,7 @@ public class SpecificationUtil implements CONST_IMPL {
         }
         SpecificationNode mayaa = getMayaaNode(spec);
         if (mayaa != null) {
-        	if (_eventScripts.isCached(spec, eventName)) {
-        		_eventScripts.execEventScripts(spec, eventName);
-        	} else {
-        		List<NodeTreeWalker> eventChilds = new ArrayList<>();
-	            for (Iterator<NodeTreeWalker> it = mayaa.iterateChildNode(); it.hasNext();) {
-	                SpecificationNode child = (SpecificationNode) it.next();
-	                if (eventName.equals(child.getQName())) {
-	                	eventChilds.add(child);
-	                }
-	            }
-        		_eventScripts.execEventScriptsAndCache(spec, eventName, eventChilds);
-        	}
+            _eventScripts.execEvent(spec, eventName, mayaa);
         }
     }
 
@@ -464,9 +455,10 @@ public class SpecificationUtil implements CONST_IMPL {
 
     protected static class EventScriptEnvironment {
 
-		// WeakHashMap<Specification, Map<QName, List<CompiledScript>>>
-        private Map<Specification, Map<QName, List<CompiledScript>>> _mayaaScriptCache
-             = Collections.synchronizedMap(new WeakHashMap<Specification, Map<QName, List<CompiledScript>>>());
+        private final Cache<Specification, ConcurrentMap<QName, List<CompiledScript>>> _mayaaScriptCache
+            = Caffeine.newBuilder()
+                .weakKeys()
+                .build();
 
         protected CompiledScript compile(String text) {
             if (StringUtil.hasValue(text)) {
@@ -477,28 +469,41 @@ public class SpecificationUtil implements CONST_IMPL {
         }
 
         protected List<CompiledScript> getEventScripts(Specification spec, QName eventName) {
-        	Map<QName, List<CompiledScript>> events = _mayaaScriptCache.get(spec);
-        	if (events == null) {
-        		return null;
-        	}
-        	return events.get(eventName);
+            ConcurrentMap<QName, List<CompiledScript>> events = _mayaaScriptCache.getIfPresent(spec);
+            if (events == null) {
+                return null;
+            }
+            return events.get(eventName);
         }
 
-        public boolean isCached(Specification spec, QName eventName) {
-        	return getEventScripts(spec, eventName) != null;
+        public void execEvent(
+                Specification spec, QName eventName, SpecificationNode mayaa) {
+            ConcurrentMap<QName, List<CompiledScript>> events = _mayaaScriptCache.get(
+                    spec, key -> new ConcurrentHashMap<>());
+            List<CompiledScript> scripts = events.get(eventName);
+            if (scripts == null) {
+                List<NodeTreeWalker> eventChilds = new ArrayList<>();
+                for (Iterator<NodeTreeWalker> it = mayaa.iterateChildNode(); it.hasNext();) {
+                    SpecificationNode child = (SpecificationNode) it.next();
+                    if (eventName.equals(child.getQName())) {
+                        eventChilds.add(child);
+                    }
+                }
+                scripts = compileAndPrimeScripts(eventChilds);
+                List<CompiledScript> existing = events.putIfAbsent(eventName, scripts);
+                if (existing == null) {
+                    return;
+                }
+                scripts = existing;
+            }
+            execScripts(scripts);
         }
 
-        public boolean execEventScriptsAndCache(
-        		Specification spec, QName eventName, List<NodeTreeWalker> eventChilds) {
-        	if (eventChilds == null) {
-        		throw new NullPointerException();
-        	}
-        	Map<QName, List<CompiledScript>> events = _mayaaScriptCache.get(spec);
-        	if (events == null) {
-        		events = new HashMap<>();
-        		_mayaaScriptCache.put(spec, events);
-        	}
-        	List<CompiledScript> scripts = new ArrayList<>();
+        private List<CompiledScript> compileAndPrimeScripts(List<NodeTreeWalker> eventChilds) {
+            if (eventChilds == null) {
+                throw new NullPointerException();
+            }
+            List<CompiledScript> scripts = new ArrayList<>();
 
             ServiceCycle cycle = CycleUtil.getServiceCycle();
             for (Iterator<NodeTreeWalker> it = eventChilds.iterator(); it.hasNext();) {
@@ -516,19 +521,15 @@ public class SpecificationUtil implements CONST_IMPL {
                 }
             }
             if (scripts.size() == 0) {
-            	events.put(eventName, new ArrayList<CompiledScript>());
-            } else {
-            	events.put(eventName, scripts);
+                return new ArrayList<CompiledScript>();
             }
-        	return true;
+            return scripts;
         }
 
-        public boolean execEventScripts(
-        		Specification spec, QName eventName) {
-        	List<CompiledScript> scripts = getEventScripts(spec, eventName);
-        	if (scripts == null) {
-        		return false;
-        	}
+        private void execScripts(List<CompiledScript> scripts) {
+            if (scripts == null) {
+                return;
+            }
             ServiceCycle cycle = CycleUtil.getServiceCycle();
             for (CompiledScript script : scripts) {
                 NodeTreeWalker save = cycle.getInjectedNode();
@@ -538,9 +539,7 @@ public class SpecificationUtil implements CONST_IMPL {
                     cycle.setInjectedNode(save);
                 }
             }
-            return true;
         }
-
     }
 
     public static Namespace copyNamespace(Namespace original) {

--- a/src-impl/org/seasar/mayaa/impl/source/ClassLoaderSourceDescriptor.java
+++ b/src-impl/org/seasar/mayaa/impl/source/ClassLoaderSourceDescriptor.java
@@ -38,9 +38,9 @@ public class ClassLoaderSourceDescriptor
 
     private String _root = "";
     private Class<?> _neighbor;
-    private URL _url;
-    private File _file;
-    private Date _timestamp;
+    private volatile URL _url;
+    private volatile File _file;
+    private volatile Date _timestamp;
 
     private SourceAlias _alias;
     private String _systemID = "";
@@ -100,17 +100,22 @@ public class ClassLoaderSourceDescriptor
 
     protected void prepareURL() {
         String path = (_root + getSystemID()).substring(1);
+        URL resolvedUrl = null;
         if (_neighbor != null) {
-            _url = IOUtil.getResource(path, _neighbor);
+            resolvedUrl = IOUtil.getResource(path, _neighbor);
         }
-        if (_url == null) {
+        if (resolvedUrl == null) {
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            _url = IOUtil.getResource(path, loader);
+            resolvedUrl = IOUtil.getResource(path, loader);
         }
-        _file = IOUtil.getFile(_url);
-        if (_timestamp == null && _file == null) {
-            _timestamp = new Date();
+        File resolvedFile = IOUtil.getFile(resolvedUrl);
+        Date resolvedTimestamp = _timestamp;
+        if (resolvedTimestamp == null && resolvedFile == null) {
+            resolvedTimestamp = new Date();
         }
+        _timestamp = resolvedTimestamp;
+        _file = resolvedFile;
+        _url = resolvedUrl;
     }
 
     public InputStream getInputStream() {

--- a/test-war/jfr-analyze.sh
+++ b/test-war/jfr-analyze.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# jfr-analyze.sh  ― JFR 単体分析 & 2ファイル差分比較
+#
+# 使い方:
+#   ./test-war/jfr-analyze.sh  <jfr-file>              # 単体分析
+#   ./test-war/jfr-analyze.sh  <jfr-A>  <jfr-B>        # 差分比較 (A=Cold, B=Base など)
+#
+# 前提: jfr (JDK 付属), jq が PATH に存在すること
+set -euo pipefail
+
+# ─── ユーティリティ ───────────────────────────────────────────────────────────
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' が見つかりません。JDK の bin と jq を PATH に追加してください。" >&2; exit 1; }
+}
+require_cmd jfr
+require_cmd jq
+
+# 一時ディレクトリ (終了時に自動削除)
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# 1つの JFR ファイルから指標を JSON として stdout に出力する
+# 引数: <jfr-file>  <label>
+analyze_jfr() {
+  local jfr="$1"
+  local label="$2"
+
+  [[ -f "$jfr" ]] || { echo "ERROR: ファイルが見つかりません: $jfr" >&2; exit 1; }
+
+  local slug
+  slug=$(basename "$jfr" .jfr | tr -c 'A-Za-z0-9_-' '_')
+
+  # ── JavaMonitorEnter ────────────────────────────────────────────────────────
+  local mon_file="$TMPDIR_WORK/${slug}_mon.json"
+  jfr print --json --events jdk.JavaMonitorEnter "$jfr" >"$mon_file" 2>/dev/null \
+    || echo '{"recording":{"events":[]}}' >"$mon_file"
+
+  # ── GarbageCollection ───────────────────────────────────────────────────────
+  local gc_file="$TMPDIR_WORK/${slug}_gc.json"
+  jfr print --json --events jdk.GarbageCollection "$jfr" >"$gc_file" 2>/dev/null \
+    || echo '{"recording":{"events":[]}}' >"$gc_file"
+
+  # ── ExecutionSample ─────────────────────────────────────────────────────────
+  local exec_file="$TMPDIR_WORK/${slug}_exec.json"
+  jfr print --json --events jdk.ExecutionSample "$jfr" >"$exec_file" 2>/dev/null \
+    || echo '{"recording":{"events":[]}}' >"$exec_file"
+
+  # ── jq で集計 (ファイル経由で渡す) ─────────────────────────────────────────
+  jq -n \
+    --arg label  "$label" \
+    --slurpfile mon  "$mon_file" \
+    --slurpfile gc   "$gc_file" \
+    --slurpfile exec "$exec_file" \
+    '
+    # ─ ヘルパ ─────────────────────────────────────
+    def ms:   (.values.duration | capture("PT(?<s>[0-9.]+)S").s | tonumber * 1000);
+    def mon_cls: (.values.monitorClass.name // "unknown");
+    def mayaa_top:
+      [.values.stackTrace.frames[]?.method.type.name | select(startswith("org/seasar/mayaa"))][0] // null;
+    def has_mayaa:
+      ([.values.stackTrace.frames[]?.method.type.name | select(startswith("org/seasar/mayaa"))] | length) > 0;
+
+    # ─ JavaMonitorEnter ───────────────────────────
+    ($mon[0].recording.events) as $me |
+    ($me | length) as $mc |
+    ($me | if $mc == 0 then [] else map(ms) end) as $mms |
+    ($mms | if length == 0 then 0 else add end) as $mtot |
+    ($mms | sort) as $msorted |
+    ($msorted | if length == 0 then 0 else .[(($mc * 0.50) | floor)] end) as $p50 |
+    ($msorted | if length == 0 then 0 else .[(($mc * 0.90) | floor)] end) as $p90 |
+    ($msorted | if length == 0 then 0 else .[(($mc * 0.99) | floor)] end) as $p99 |
+    ($msorted | if length == 0 then 0 else last end) as $pmax |
+
+    # monitorClass 別集計 (上位5)
+    ($me | group_by(mon_cls) |
+      map({cls: (.[0] | mon_cls), cnt: length, total_ms: (map(ms) | add), avg_ms: ((map(ms) | add) / length)}) |
+      sort_by(-.total_ms) | .[0:5]) as $mon_by_cls |
+
+    # Mayaa スタック別集計 (上位5)
+    ($me | map(select(mayaa_top != null) | {k: ((mon_cls) + "|" + mayaa_top), d: ms}) |
+      group_by(.k) |
+      map({key: .[0].k, cnt: length, total_ms: (map(.d) | add), avg_ms: ((map(.d) | add) / length)}) |
+      sort_by(-.total_ms) | .[0:5]) as $mon_by_mayaa |
+
+    # ─ GarbageCollection ─────────────────────────
+    ($gc[0].recording.events) as $ge |
+    ($ge | length) as $gcnt |
+    ($ge | if $gcnt == 0 then [] else map(ms) end) as $gcms |
+    ($gcms | if length == 0 then 0 else add end) as $gctot |
+    ($gcms | if length == 0 then 0 else add / $gcnt end) as $gcavg |
+    ($gcms | if length == 0 then 0 else max end) as $gcmax |
+
+    # ─ ExecutionSample ───────────────────────────
+    ($exec[0].recording.events) as $ee |
+    ($ee | length) as $ecnt |
+    ($ee | map(select(has_mayaa)) | length) as $emayaa |
+    ($ee | map(select(has_mayaa) | mayaa_top) | group_by(.) |
+      map({cls: .[0], cnt: length}) | sort_by(-.cnt) | .[0:8]) as $mayaa_top_classes |
+
+    # ─ 出力オブジェクト ──────────────────────────
+    {
+      label:   $label,
+      monitor: {
+        count:     $mc,
+        total_ms:  ($mtot | (. * 100 | round) / 100),
+        avg_ms:    (if $mc == 0 then 0 else (($mtot / $mc) * 100 | round) / 100 end),
+        p50_ms:    ($p50 | (. * 100 | round) / 100),
+        p90_ms:    ($p90 | (. * 100 | round) / 100),
+        p99_ms:    ($p99 | (. * 100 | round) / 100),
+        max_ms:    ($pmax | (. * 100 | round) / 100),
+        by_class:  $mon_by_cls,
+        by_mayaa:  $mon_by_mayaa
+      },
+      gc: {
+        count:     $gcnt,
+        total_ms:  ($gctot | (. * 100 | round) / 100),
+        avg_ms:    ($gcavg | (. * 100 | round) / 100),
+        max_ms:    ($gcmax | (. * 100 | round) / 100)
+      },
+      exec_sample: {
+        count:        $ecnt,
+        mayaa_count:  $emayaa,
+        mayaa_ratio:  (if $ecnt == 0 then 0 else (($emayaa * 1000 / $ecnt | round) / 10) end),
+        mayaa_top_classes: $mayaa_top_classes
+      }
+    }
+    '
+}
+
+# テキスト表示 (1ファイル分の集計 JSON を受け取って整形)
+print_report() {
+  local json="$1"
+  echo "$json" | jq -r '
+    "═══════════════════════════════════════════════════════════════",
+    "  ファイル : \(.label)",
+    "═══════════════════════════════════════════════════════════════",
+    "",
+    "■ JavaMonitorEnter",
+    "  件数        : \(.monitor.count)",
+    "  合計待機    : \(.monitor.total_ms) ms",
+    "  平均待機    : \(.monitor.avg_ms) ms",
+    "  p50         : \(.monitor.p50_ms) ms",
+    "  p90         : \(.monitor.p90_ms) ms",
+    "  p99         : \(.monitor.p99_ms) ms",
+    "  max         : \(.monitor.max_ms) ms",
+    "",
+    "  ─ monitorClass 内訳 (上位5) ─",
+    "  \(["cls","cnt","total_ms","avg_ms"] | @tsv)",
+    (.monitor.by_class[] | "  \([.cls, .cnt, (.total_ms | (.*100|round)/100), (.avg_ms | (.*100|round)/100)] | @tsv)"),
+    "",
+    "  ─ Mayaa スタック内訳 (上位5) ─",
+    "  \(["monitorClass|mayaaClass","cnt","total_ms","avg_ms"] | @tsv)",
+    (.monitor.by_mayaa[] | "  \([.key, .cnt, (.total_ms | (.*100|round)/100), (.avg_ms | (.*100|round)/100)] | @tsv)"),
+    "",
+    "■ GarbageCollection",
+    "  件数 : \(.gc.count)   合計: \(.gc.total_ms) ms   平均: \(.gc.avg_ms) ms   max: \(.gc.max_ms) ms",
+    "",
+    "■ ExecutionSample",
+    "  総件数     : \(.exec_sample.count)",
+    "  Mayaa 件数 : \(.exec_sample.mayaa_count)  (\(.exec_sample.mayaa_ratio)%)",
+    "  ─ Mayaa スタック内トップクラス ─",
+    (.exec_sample.mayaa_top_classes[] | "  \(.cnt)\t\(.cls)"),
+    ""
+  '
+}
+
+# 2ファイル差分比較
+print_diff() {
+  local a_json="$1"
+  local b_json="$2"
+  jq -rn \
+    --argjson a "$a_json" \
+    --argjson b "$b_json" \
+    '
+    def diff(x; y): (if y == 0 then "N/A" else (((y - x) / x * 1000 | round) / 10 | tostring) + "%" end);
+    def arrow(x; y): if y > x then "▲" elif y < x then "▼" else "=" end;
+    def fmt(v): v | (. * 100 | round) / 100 | tostring;
+
+    "═══════════════════════════════════════════════════════════════",
+    "  差分比較: A=[\($a.label | split("/") | last)]  vs  B=[\($b.label | split("/") | last)]",
+    "  数値: A → B  (B-A の変化率; ▲=増加 ▼=減少)",
+    "═══════════════════════════════════════════════════════════════",
+    "",
+    "■ JavaMonitorEnter",
+    "  件数     : \($a.monitor.count) → \($b.monitor.count)  \(arrow($a.monitor.count; $b.monitor.count)) \(diff($a.monitor.count; $b.monitor.count))",
+    "  合計ms   : \(fmt($a.monitor.total_ms)) → \(fmt($b.monitor.total_ms))  \(arrow($a.monitor.total_ms; $b.monitor.total_ms)) \(diff($a.monitor.total_ms; $b.monitor.total_ms))",
+    "  avg ms   : \(fmt($a.monitor.avg_ms)) → \(fmt($b.monitor.avg_ms))  \(arrow($a.monitor.avg_ms; $b.monitor.avg_ms)) \(diff($a.monitor.avg_ms; $b.monitor.avg_ms))",
+    "  p50 ms   : \(fmt($a.monitor.p50_ms)) → \(fmt($b.monitor.p50_ms))  \(arrow($a.monitor.p50_ms; $b.monitor.p50_ms)) \(diff($a.monitor.p50_ms; $b.monitor.p50_ms))",
+    "  p90 ms   : \(fmt($a.monitor.p90_ms)) → \(fmt($b.monitor.p90_ms))  \(arrow($a.monitor.p90_ms; $b.monitor.p90_ms)) \(diff($a.monitor.p90_ms; $b.monitor.p90_ms))",
+    "  p99 ms   : \(fmt($a.monitor.p99_ms)) → \(fmt($b.monitor.p99_ms))  \(arrow($a.monitor.p99_ms; $b.monitor.p99_ms)) \(diff($a.monitor.p99_ms; $b.monitor.p99_ms))",
+    "  max ms   : \(fmt($a.monitor.max_ms)) → \(fmt($b.monitor.max_ms))  \(arrow($a.monitor.max_ms; $b.monitor.max_ms)) \(diff($a.monitor.max_ms; $b.monitor.max_ms))",
+    "",
+    "■ GarbageCollection",
+    "  件数     : \($a.gc.count) → \($b.gc.count)  \(arrow($a.gc.count; $b.gc.count)) \(diff($a.gc.count; $b.gc.count))",
+    "  合計ms   : \(fmt($a.gc.total_ms)) → \(fmt($b.gc.total_ms))  \(arrow($a.gc.total_ms; $b.gc.total_ms)) \(diff($a.gc.total_ms; $b.gc.total_ms))",
+    "  avg ms   : \(fmt($a.gc.avg_ms)) → \(fmt($b.gc.avg_ms))  \(arrow($a.gc.avg_ms; $b.gc.avg_ms)) \(diff($a.gc.avg_ms; $b.gc.avg_ms))",
+    "  max ms   : \(fmt($a.gc.max_ms)) → \(fmt($b.gc.max_ms))  \(arrow($a.gc.max_ms; $b.gc.max_ms)) \(diff($a.gc.max_ms; $b.gc.max_ms))",
+    "",
+    "■ ExecutionSample",
+    "  総件数   : \($a.exec_sample.count) → \($b.exec_sample.count)  \(arrow($a.exec_sample.count; $b.exec_sample.count)) \(diff($a.exec_sample.count; $b.exec_sample.count))",
+    "  Mayaa数  : \($a.exec_sample.mayaa_count) → \($b.exec_sample.mayaa_count)  \(arrow($a.exec_sample.mayaa_count; $b.exec_sample.mayaa_count)) \(diff($a.exec_sample.mayaa_count; $b.exec_sample.mayaa_count))",
+    "  比率     : \($a.exec_sample.mayaa_ratio)% → \($b.exec_sample.mayaa_ratio)%",
+    ""
+  '
+}
+
+# ─── メイン ──────────────────────────────────────────────────────────────────
+
+if [[ $# -eq 0 || $# -gt 2 ]]; then
+  echo "Usage: $0 <jfr-file> [<jfr-file-baseline>]" >&2
+  exit 1
+fi
+
+JFR_A="$1"
+A_LABEL="$(basename "$JFR_A")"
+echo "分析中: $JFR_A ..." >&2
+A_JSON=$(analyze_jfr "$JFR_A" "$A_LABEL")
+print_report "$A_JSON"
+
+if [[ $# -eq 2 ]]; then
+  JFR_B="$2"
+  B_LABEL="$(basename "$JFR_B")"
+  echo "分析中: $JFR_B ..." >&2
+  B_JSON=$(analyze_jfr "$JFR_B" "$B_LABEL")
+  print_report "$B_JSON"
+  print_diff "$A_JSON" "$B_JSON"
+fi


### PR DESCRIPTION
## 概要

JFR プロファイリング（`flight_recording_20260314_122248.jfr`）による負荷試験（Mayaa-Cold シナリオ, 48スレッド, 180秒）で、**ほぼ唯一のボトルネックが `java.util.Collections$SynchronizedMap` のモニター競合**であることを定量的に確認した。

## 観測値（Mayaa-Cold=6, 48スレッド）

| 指標 | 値 |
|---|---|
| JavaMonitorEnter 件数 | 1,002 件 |
| 競合合計待機時間 | 23,627 ms |
| 平均待機 | 23.58 ms |
| p50 / p90 / p99 / max | 16.6 / 54.4 / 70.0 / 70.6 ms |
| CPU サンプル中の Mayaa 比率 | 39.1 % |

競合の 99.9% は `java/util/Collections$SynchronizedMap` 1 クラスに集中し、
呼び出し元は **すべて `SpecificationUtil$EventScriptEnvironment`** の経路。

## ベースライン計測結果（Balanced=6, Mayaa-Cold=0）

計測日: 2026-03-14

- Baseline JFR: `flight_recording_20260314_153233.jfr`
- 比較対象 Cold JFR: `flight_recording_20260314_122248.jfr`
- 差分分析: `./test-war/jfr-analyze.sh flight_recording_20260314_122248.jfr flight_recording_20260314_153233.jfr`

### 差分サマリ（Cold → Baseline）

| 指標 | Cold | Baseline | 変化 |
|---|---:|---:|---:|
| JavaMonitorEnter 件数 | 1002 | 852 | -15.0% |
| monitor 合計待機 ms | 23627.19 | 25739.04 | +8.9% |
| monitor 平均待機 ms | 23.58 | 30.21 | +28.1% |
| monitor p99 ms | 70.04 | 118.41 | +69.1% |
| monitor max ms | 70.57 | 118.79 | +68.3% |

### 解釈

- Baseline（Mayaa-Cold=0）でも monitor 競合は継続し、待機時間分布はむしろ悪化。
- 競合クラスは引き続き `java.util.Collections$SynchronizedMap` に集中。
- よって、問題は「Cold シナリオ固有」ではなく、`EventScriptEnvironment` キャッシュ実装の構造的ボトルネックと判断。

## 根本原因

`SpecificationUtil.java` 内 `EventScriptEnvironment` が持つキャッシュ:

```java
// 現状（問題あり）
private Map<Specification, Map<QName, List<CompiledScript>>> _mayaaScriptCache
    = Collections.synchronizedMap(
        new WeakHashMap<Specification, Map<QName, List<CompiledScript>>>());
```

- **外側マップ全体に単一ロック** → ホットパスで全スレッドが直列化される
- `execEventScriptsAndCache` が check-then-act を同期ブロック外で実施 → 複合操作の非原子性も潜在する
- Cold パスで顕在化しやすいが、通常シナリオでも競合は発生している

## 方針（暫定）

| 案 | 内容 |
|---|---|
| **A: ConcurrentHashMap + computeIfAbsent** | `WeakHashMap` の弱参照を明示的 `WeakReference` + `ReferenceQueue` で代替。実装コストは高いがロックフリー |
| **B: read-write ロック分離** | `ReentrantReadWriteLock` でリードの並列化だけを図る。実装コストは低い |
| **C: Caffeine 弱キーキャッシュ** | `Caffeine.newBuilder().weakKeys().build()` に置き換え。弱参照と並列性を両立 |

Caffeine は `ecc1c5ff` で既に導入済みなので **案 C を優先評価** する。

## 作業範囲

- [ ] `SpecificationUtil.EventScriptEnvironment` のキャッシュ実装を置換
- [ ] 後続の check-then-act パターンを原子的操作へ書き換え
- [ ] 単体テスト: 並列アクセス下での正確性確認
- [ ] 負荷試験: JavaMonitorEnter 件数・待機時間分位（p50/p90/p99/max）の再比較

## ベースライン計測コマンド（参考）

```bash
# ベースライン (Cold=0)
JMETER_THREAD=48 JMETER_RAMPUP=20 JMETER_DURATION=180 JMETER_DELAY=10 \
PERF_MIX_BALANCED=6 PERF_MIX_MAYAA_COLD=0 \
./test-war/run-jmeter-with-jfr.sh

# 差分比較
./test-war/jfr-analyze.sh <cold.jfr> <baseline.jfr>
```

## 関連

- ベースブランチ: `develop-2.0`
- Caffeine 導入コミット: `ecc1c5ff`
- 分析スクリプト: `test-war/jfr-analyze.sh`
