### PR TITLE
SCOPEマクロが展開できていなかったので展開タイミングを変更

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/TemplateBuilderImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/TemplateBuilderImpl.java
@@ -42,6 +42,7 @@ import org.seasar.mayaa.engine.Template;
 import org.seasar.mayaa.engine.processor.OptimizableProcessor;
 import org.seasar.mayaa.engine.processor.ProcessorTreeWalker;
 import org.seasar.mayaa.engine.processor.TemplateProcessor;
+import org.seasar.mayaa.engine.specification.NodeAttribute;
 import org.seasar.mayaa.engine.specification.NodeTreeWalker;
 import org.seasar.mayaa.engine.specification.PrefixMapping;
 import org.seasar.mayaa.engine.specification.QName;
@@ -52,6 +53,7 @@ import org.seasar.mayaa.impl.builder.injection.DefaultInjectionChain;
 import org.seasar.mayaa.impl.builder.parser.HtmlTemplateParser;
 import org.seasar.mayaa.impl.builder.parser.NekoHtmlParser;
 import org.seasar.mayaa.impl.cycle.CycleUtil;
+import org.seasar.mayaa.impl.cycle.script.ScriptUtil;
 import org.seasar.mayaa.impl.engine.processor.AttributeProcessor;
 import org.seasar.mayaa.impl.engine.processor.CharactersProcessor;
 import org.seasar.mayaa.impl.engine.processor.CommentProcessor;
@@ -528,6 +530,44 @@ public class TemplateBuilderImpl extends SpecificationBuilderImpl
         return processor;
     }
 
+    protected void rewriteScopeMacrosForScriptCharacters(
+            NodeTreeWalker parent,
+            SpecificationNode original,
+            SpecificationNode injected) {
+        if (parent == null || original == null || injected == null) {
+            return;
+        }
+        if (QM_CHARACTERS.equals(original.getQName()) == false) {
+            return;
+        }
+        if (parent instanceof SpecificationNode == false) {
+            return;
+        }
+        QName parentQName = ((SpecificationNode) parent).getQName();
+        if (parentQName == null
+                || "script".equalsIgnoreCase(parentQName.getLocalName()) == false) {
+            return;
+        }
+        rewriteScopeMacrosOnCharactersNode(original);
+        if (injected != original) {
+            rewriteScopeMacrosOnCharactersNode(injected);
+        }
+    }
+
+    protected void rewriteScopeMacrosOnCharactersNode(SpecificationNode node) {
+        NodeAttribute textAttribute = node.getAttribute(QM_TEXT);
+        if (textAttribute == null) {
+            return;
+        }
+        String text = textAttribute.getValue();
+        String rewritten = ScriptUtil.rewriteScopeMacrosForScriptContext(text);
+        if (rewritten.equals(text)) {
+            return;
+        }
+        node.removeAttribute(QM_TEXT);
+        node.addAttribute(QM_TEXT, rewritten);
+    }
+
     protected SpecificationNode resolveOriginalNode(
             SpecificationNode original, InjectionChain chain) {
         if (original == null || chain == null) {
@@ -564,6 +604,7 @@ public class TemplateBuilderImpl extends SpecificationBuilderImpl
             if (injected == null) {
                 throw new TemplateNodeNotResolvedException(original.toString());
             }
+            rewriteScopeMacrosForScriptCharacters(original, child, injected);
             saveToCycle(child, injected);
             ProcessorTreeWalker processor = resolveInjectedNode(
                     template, stack, child, injected, divided);

--- a/src-impl/org/seasar/mayaa/impl/cycle/script/ScriptUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/cycle/script/ScriptUtil.java
@@ -15,12 +15,9 @@
  */
 package org.seasar.mayaa.impl.cycle.script;
 
-import org.seasar.mayaa.cycle.ServiceCycle;
 import org.seasar.mayaa.cycle.script.CompiledScript;
 import org.seasar.mayaa.cycle.script.ScriptEnvironment;
 import org.seasar.mayaa.engine.specification.NodeTreeWalker;
-import org.seasar.mayaa.engine.specification.QName;
-import org.seasar.mayaa.engine.specification.SpecificationNode;
 import org.seasar.mayaa.impl.cycle.CycleUtil;
 import org.seasar.mayaa.impl.provider.ProviderUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
@@ -36,38 +33,14 @@ public class ScriptUtil {
 
     public static CompiledScript compile(String text) {
         CompiledScript compiled;
-        String targetText = text;
         if (StringUtil.hasValue(text)) {
             ScriptEnvironment environment = ProviderUtil.getScriptEnvironment();
-            ServiceCycle cycle = CycleUtil.getServiceCycle();
-            NodeTreeWalker node = cycle.getInjectedNode();
-            if (isScriptContextNode(node)) {
-                targetText = ScriptScopeMacroRewriter.rewriteToScriptBlocks(text);
-            }
-            compiled = environment.compile(targetText, node);
+            NodeTreeWalker node = CycleUtil.getServiceCycle().getInjectedNode();
+            compiled = environment.compile(text, node);
         } else {
             compiled = LiteralScript.NULL_LITERAL_SCRIPT;
         }
         return compiled;
-    }
-
-    private static boolean isScriptContextNode(NodeTreeWalker node) {
-        NodeTreeWalker current = node;
-        while (current != null) {
-            if (current instanceof SpecificationNode) {
-                SpecificationNode specNode = (SpecificationNode) current;
-                QName qName = specNode.getQName();
-                if (qName != null && "script".equalsIgnoreCase(qName.getLocalName())) {
-                    return true;
-                }
-            }
-            try {
-                current = current.getParentNode();
-            } catch (UnsupportedOperationException e) {
-                current = null;
-            }
-        }
-        return false;
     }
 
     public static String getBlockSignedText(String text) {
@@ -76,6 +49,10 @@ public class ScriptUtil {
         }
         String blockSign = ProviderUtil.getScriptEnvironment().getBlockSign();
         return blockSign + "{" + text.trim() + "\n}";
+    }
+
+    public static String rewriteScopeMacrosForScriptContext(String text) {
+        return ScriptScopeMacroRewriter.rewriteToScriptBlocks(text);
     }
 
     public static void assertSingleScript(String text) {

--- a/src/test/java/org/seasar/mayaa/functional/engine/AutoEscapeIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/AutoEscapeIntegrationTest.java
@@ -105,13 +105,15 @@ public class AutoEscapeIntegrationTest extends EngineTestBase {
         vars.put("msg", "<b>bold</b> & 'quote'");
 
         String target = """
-                <!-- m:autoEscape=true --><!DOCTYPE html>
+                <!-- m:autoEscape=true -->
+                <!DOCTYPE html>
                 <html><head></head><body>
                 <div>${msg}</div>
                 </body></html>
                 """;
 
         String expected = """
+                <!-- m:autoEscape=true -->
                 <!DOCTYPE html>
                 <html><head></head><body>
                 <div>&lt;b&gt;bold&lt;/b&gt; &amp; 'quote'</div>
@@ -131,13 +133,15 @@ public class AutoEscapeIntegrationTest extends EngineTestBase {
         vars.put("msg", "<b>bold</b> & 'quote'");
 
         String target = """
-                <!-- m:autoEscape=false --><!DOCTYPE html>
+                <!-- m:autoEscape=false -->
+                <!DOCTYPE html>
                 <html><head></head><body>
                 <div>${msg}</div>
                 </body></html>
                 """;
 
         String expected = """
+                <!-- m:autoEscape=false -->
                 <!DOCTYPE html>
                 <html><head></head><body>
                 <div><b>bold</b> & 'quote'</div>
@@ -641,6 +645,89 @@ public class AutoEscapeIntegrationTest extends EngineTestBase {
                 """;
 
         registerAndVerify("raw-marker", target, expected, vars);
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void MAYAA_SCOPEマクロはscriptコンテキストで_ドル括弧なしでもJSリテラル展開される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(true);
+
+        Map<String, Object> vars = new LinkedHashMap<String, Object>();
+        vars.put("name", "Tom \"The Cat\"");
+        vars.put("title", "Mayaa");
+
+        String target = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <script>
+                const userName = MAYAA_SCOPE(name);
+                const title = MAYAA_SCOPE_AS_STRING(title);
+                if (userName === "Tom \\"The Cat\\"" && title === "Mayaa") {
+                    document.getElementById("marker").textContent = "ok";
+                }
+                </script>
+                <div id="marker">ok</div>
+                </body></html>\
+                """;
+
+        String expected = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <script>
+                const userName = "Tom \\\"The Cat\\\"";
+                const title = "Mayaa";
+                if (userName === "Tom \\"The Cat\\"" && title === "Mayaa") {
+                    document.getElementById("marker").textContent = "ok";
+                }
+                </script>
+                <div id="marker">ok</div>
+                </body></html>\
+                """;
+
+        registerAndVerify("scope-macro-script", target, expected, vars);
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void MAYAA_SCOPE_WITH_STRINGIFYはscriptコンテキストで_ドル括弧なしでもJSON展開される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(true);
+
+        Map<String, Object> profile = new LinkedHashMap<String, Object>();
+        profile.put("name", "Alice");
+        profile.put("count", Integer.valueOf(2));
+
+        Map<String, Object> vars = new LinkedHashMap<String, Object>();
+        vars.put("user", profile);
+
+        String target = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <script>
+                const payload = MAYAA_SCOPE_WITH_STRINGIFY(user);
+                if (payload.name === "Alice" && payload.count === 2) {
+                    document.getElementById("marker").textContent = "ok";
+                }
+                </script>
+                </body></html>\
+                """;
+
+        String expected = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <script>
+                const payload = {"name":"Alice","count":2};
+                if (payload.name === "Alice" && payload.count === 2) {
+                    document.getElementById("marker").textContent = "ok";
+                }
+                </script>
+                </body></html>\
+                """;
+
+        registerAndVerify("scope-macro-stringify", target, expected, vars);
     }
 
     private Map<String, Object> createPageScope() {


### PR DESCRIPTION
SCOPEマクロが展開できていなかったのを修正。
ビルドフェースで展開処理を実施することでレンダリング時に負荷をかけないようにしている。