### PR TITLE
fix: Spec更新検知の精度向上とisDeprecated呼び出し回数の最適化

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
@@ -79,6 +79,8 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
     public static final String DUMP_ENABLED = "dumpEnabled";
     public static final String CONVERT_CHARSET = "convertCharset";
     public static final String NO_CACHE_VALUE = "noCacheValue";
+    private static final String REQUEST_VALID_SPEC_CACHE_KEY =
+            EngineImpl.class.getName() + ".requestValidSpecCache";
 
     private transient AtomicReference<Specification> _defaultSpecification = new AtomicReference<>(null);
 
@@ -149,7 +151,55 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
     }
 
     public Specification findSpecificationFromCache(String systemID) {
-        return _specCache.getIfPresent(systemID);
+        return findValidSpecificationFromCache(systemID);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Map<String, Specification> getRequestValidSpecCache() {
+        RequestScope request = CycleUtil.getRequestScope();
+        if (request == null) {
+            return null;
+        }
+        Object cached = request.getAttribute(REQUEST_VALID_SPEC_CACHE_KEY);
+        if (cached instanceof Map<?, ?>) {
+            return (Map<String, Specification>) cached;
+        }
+        Map<String, Specification> map = new HashMap<>();
+        request.setAttribute(REQUEST_VALID_SPEC_CACHE_KEY, map);
+        return map;
+    }
+
+    protected void clearRequestValidSpecCache(String systemID) {
+        Map<String, Specification> map = getRequestValidSpecCache();
+        if (map != null) {
+            map.remove(systemID);
+        }
+    }
+
+    protected Specification findValidSpecificationFromCache(String systemID) {
+        Map<String, Specification> requestCache = getRequestValidSpecCache();
+        if (requestCache != null && requestCache.containsKey(systemID)) {
+            return requestCache.get(systemID);
+        }
+
+        Specification cached = _specCache.getIfPresent(systemID);
+        if (cached == null) {
+            if (requestCache != null) {
+                requestCache.put(systemID, null);
+            }
+            return null;
+        }
+        if (cached.isDeprecated()) {
+            _specCache.invalidate(systemID);
+            if (requestCache != null) {
+                requestCache.put(systemID, null);
+            }
+            return null;
+        }
+        if (requestCache != null) {
+            requestCache.put(systemID, cached);
+        }
+        return cached;
     }
 
     /**
@@ -160,6 +210,7 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
         if (Objects.nonNull(spec)) {
             spec.deprecate();
         }
+        clearRequestValidSpecCache(systemID);
         if (withSerialized) {
             SpecificationUtil.purgeSerializedFile(systemID);
         }
@@ -174,7 +225,7 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
     }
 
     protected Page findPageFromCache(String pageName) {
-        return (Page) findSpecificationFromCache(pageName + _mayaaExtension);
+        return (Page) findValidSpecificationFromCache(pageName + _mayaaExtension);
     }
 
     public Page getPage(String pageName) {
@@ -503,10 +554,6 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
             SpecificationUtil.startScope(null);
             try {
                 spec.build(rebuild);
-
-                if (spec.isDeprecated()) {
-                    return spec;
-                }
                 if (isSerializeEnabled()) {
                     submitSerialize(spec);
                 }
@@ -517,7 +564,10 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
             throw e;
         }
         if (registerCache) {
+            // Pageの.mayaaが存在しない場合でもSpecificationをキャッシュする。
+            // これにより同一ページへのリクエストで毎回Specificationを再生成せずに済む。
             _specCache.put(spec.getSystemID(), spec);
+            clearRequestValidSpecCache(spec.getSystemID());
         }
         return spec;
     }
@@ -549,7 +599,7 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
 
     public Template createTemplateInstance(final Page page, final String suffix, final String extension) {
         final String templateId = getTemplateID(page, suffix, extension);
-        Specification cached = _specCache.getIfPresent(templateId);
+        Specification cached = findValidSpecificationFromCache(templateId);
         if (cached != null) {
             return (Template) cached;
         }
@@ -573,6 +623,7 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
         if (existing != null) {
             return (Template) existing;
         }
+        clearRequestValidSpecCache(templateId);
         return (Template) created;
     }
 

--- a/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineUtil.java
@@ -115,8 +115,24 @@ public class EngineUtil implements CONST_IMPL {
         return ObjectUtil.booleanValue(value, defaultValue);
     }
 
+    /**
+     * ServiceCycleで現在処理中のノードからparentを辿り、Specificationが
+     * 見つかった場合それを返します。
+     * 見つからない場合はnullを返します。
+     *
+     * @return Specification
+     */
+    private static Specification findCurrentSpecification() {
+        NodeTreeWalker current = CycleUtil.getServiceCycle().getOriginalNode();
+        // リソースアクセス中にredirectしても対応できるようにする。
+        if (current != null) {
+            return SpecificationUtil.findSpecification(current);
+        }
+        return null;
+    }
+
     public static String getSourcePath() {
-        Specification spec = SpecificationUtil.findSpecification();
+        Specification spec = findCurrentSpecification();
         if (spec == null) {
             String path = CycleUtil.getServiceCycle().getRequestScope().getRequestedPath();
             SourceDescriptor source = SourceUtil.getSourceDescriptor(path);
@@ -140,11 +156,11 @@ public class EngineUtil implements CONST_IMPL {
     }
 
     public static Template getTemplate() {
-        Specification spec = SpecificationUtil.findSpecification();
+        Specification spec = findCurrentSpecification();
         if (spec instanceof Page) {
             NodeTreeWalker parent = spec.getParentNode();
             if (parent != null) {
-                spec = SpecificationUtil.findSpecification();
+                spec = findCurrentSpecification();
             } else {
                 return null;
             }

--- a/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
@@ -45,11 +45,19 @@ public class PageImpl extends SpecificationImpl implements Page {
     private static final String CURRENT_PAGE_KEY = "__currentPage__";
     private static final String CURRENT_COMPONENT_KEY = "__currentComponent__";
 
+    static final class SuperPageInfo {
+        final Page page;
+        final String suffix;
+        final String extension;
+
+        SuperPageInfo(Page page, String suffix, String extension) {
+            this.page = page;
+            this.suffix = suffix;
+            this.extension = extension;
+        }
+    }
+
     private String _pageName;
-    private transient volatile Page _superPage;
-    private transient volatile String _superSuffix;
-    private transient volatile String _superExtension;
-    private transient volatile boolean _superPrepared;
 
     private transient Map<TemplateProcessor, Boolean> _beginRenderListeners;
     private String _suffixScriptText;
@@ -65,51 +73,32 @@ public class PageImpl extends SpecificationImpl implements Page {
         _pageName = pageName;
     }
 
-    protected void prepareSuper() {
-        Page superPage = _superPage;
-        if (_superPrepared && (superPage == null || superPage.isDeprecated() == false)) {
-            return;
+    SuperPageInfo resolveSuperPageInfo() {
+        // 常に最新のextends定義を参照し、継承先はEngineキャッシュ経由で解決する。
+        String extendsPath =
+            SpecificationUtil.getMayaaAttributeValue(this, CONST_IMPL.QM_EXTENDS);
+        if (StringUtil.isEmpty(extendsPath)) {
+            return new SuperPageInfo(null, null, null);
         }
-        synchronized (this) {
-            superPage = _superPage;
-            if (_superPrepared && (superPage == null || superPage.isDeprecated() == false)) {
-                return;
-            }
-            // TODO mayaa以外からも取得できるようにする
-            String extendsPath =
-                SpecificationUtil.getMayaaAttributeValue(this, CONST_IMPL.QM_EXTENDS);
-            if (StringUtil.isEmpty(extendsPath)) {
-                _superPage = null;
-                _superSuffix = null;
-                _superExtension = null;
-                _superPrepared = true;
-                return;
-            }
-            Engine engine = ProviderUtil.getEngine();
-            String suffixSeparator = engine.getParameter(CONST_IMPL.SUFFIX_SEPARATOR);
-            String[] pagePath = StringUtil.parsePath(extendsPath, suffixSeparator);
+        Engine engine = ProviderUtil.getEngine();
+        String suffixSeparator = engine.getParameter(CONST_IMPL.SUFFIX_SEPARATOR);
+        String[] pagePath = StringUtil.parsePath(extendsPath, suffixSeparator);
 
-            _superPage = engine.getPage(
-                    StringUtil.adjustRelativePath(_pageName, pagePath[0]));
-            _superSuffix = pagePath[1];
-            _superExtension = pagePath[2];
-            _superPrepared = true;
-        }
+        Page superPage = engine.getPage(
+                StringUtil.adjustRelativePath(_pageName, pagePath[0]));
+        return new SuperPageInfo(superPage, pagePath[1], pagePath[2]);
     }
 
     public Page getSuperPage() {
-        prepareSuper();
-        return _superPage;
+        return resolveSuperPageInfo().page;
     }
 
     public String getSuperSuffix() {
-        prepareSuper();
-        return _superSuffix;
+        return resolveSuperPageInfo().suffix;
     }
 
     public String getSuperExtension() {
-        prepareSuper();
-        return _superExtension;
+        return resolveSuperPageInfo().extension;
     }
 
     public String getPageName() {
@@ -259,8 +248,7 @@ public class PageImpl extends SpecificationImpl implements Page {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(_beginRenderListeners, _pageName, _suffixScript, _suffixScriptText, _superExtension,
-                _superPage, _superPrepared, _superSuffix);
+        return Objects.hash(_beginRenderListeners, _pageName, _suffixScript, _suffixScriptText);
     }
 
     /*
@@ -278,10 +266,6 @@ public class PageImpl extends SpecificationImpl implements Page {
                 && Objects.equals(_pageName, other._pageName)
                 && Objects.equals(_suffixScript, other._suffixScript)
                 && Objects.equals(_suffixScriptText, other._suffixScriptText)
-                && Objects.equals(_superExtension, other._superExtension)
-                && Objects.equals(_superPage, other._superPage)
-            && _superPrepared == other._superPrepared
-                && Objects.equals(_superSuffix, other._superSuffix)
                 && super.equals(other);
     }
 

--- a/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
@@ -336,9 +336,16 @@ public class RenderUtil implements CONST_IMPL {
                 // LIFO access
                 templateStack.add(0, template);
             }
-            suffix = page.getSuperSuffix();
-            extension = page.getSuperExtension();
-            page = page.getSuperPage();
+            if (page instanceof PageImpl) {
+                PageImpl.SuperPageInfo superInfo = ((PageImpl) page).resolveSuperPageInfo();
+                suffix = superInfo.suffix;
+                extension = superInfo.extension;
+                page = superInfo.page;
+            } else {
+                suffix = page.getSuperSuffix();
+                extension = page.getSuperExtension();
+                page = page.getSuperPage();
+            }
             variables = null;
         } while(page != null);
         ProcessStatus ret = null;

--- a/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/specification/SpecificationUtil.java
@@ -120,23 +120,6 @@ public class SpecificationUtil implements CONST_IMPL {
     }
 
     /**
-     * ServiceCycleで現在処理中のノードからparentを辿り、Specificationが
-     * 見つかった場合それを返します。
-     * 見つからない場合はnullを返します。
-     *
-     * @return Specification
-     */
-    public static Specification findSpecification() {
-        ServiceCycle cycle = CycleUtil.getServiceCycle();
-        NodeTreeWalker current = cycle.getOriginalNode();
-        // リソースアクセス中にredirectしても対応できるようにする。
-        if (current != null) {
-            return findSpecification(current);
-        }
-        return null;
-    }
-
-    /**
      * currentが持つm:mayaaノードを探し、もしあればm:mayaaノードの属性のうち
      * qNameで表されるものの値を返します。
      * 見つからない場合はnullを返します。

--- a/src/test/java/org/seasar/mayaa/functional/engine/SpecificationLifeCycleIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/SpecificationLifeCycleIntegrationTest.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * Specification のライフサイクル(更新検知・再解決)を検証するIT。
+ */
+public class SpecificationLifeCycleIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/specification-life-cycle/";
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void レイアウトinsertで再入レンダリングするコンポーネントは次リクエストで更新を反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "layout-insert-reentry-consistency";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String componentHtmlPath = casePath + "component.html";
+        String componentMayaaPath = casePath + "component.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+
+        String targetHtml = "<div id=\"content\">PAGE</div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/layout-insert-reentry-consistency/layout.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String layoutHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                <div id="compSlot">layout-comp-default</div>
+                </body></html>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                    <m:insert id="compSlot" path="./component.html" replace="false" />
+                </m:mayaa>
+                """;
+        String componentMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:doRender id="componentRoot" replace="false" />
+                </m:mayaa>
+                """;
+        String componentHtml1 = "<div id=\"componentRoot\">COMP-OLD</div>";
+        String componentHtml2 = "<div id=\"componentRoot\">COMP-NEW</div>";
+        String expected1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <div id="compSlot"><div id="componentRoot">COMP-OLD</div></div>
+                </body></html>
+                """;
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <div id="compSlot"><div id="componentRoot">COMP-NEW</div></div>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(componentHtmlPath, componentHtml1);
+        DynamicRegisteredSourceHolder.registerContents(componentMayaaPath, componentMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(componentHtmlPath, componentHtml2);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void 共有レイアウトのHTML自体が更新された場合に次リクエストで変更を反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "layout-html-update-detection";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+
+        String targetHtml = "<div id=\"content\">PAGE</div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/layout-html-update-detection/layout.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                </m:mayaa>
+                """;
+        String layoutHtml1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                <footer>FOOTER-OLD</footer>
+                </body></html>
+                """;
+        String layoutHtml2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                <footer>FOOTER-NEW</footer>
+                </body></html>
+                """;
+        String expected1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <footer>FOOTER-OLD</footer>
+                </body></html>
+                """;
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <footer>FOOTER-NEW</footer>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml1);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml2);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void targetMayaaのextends先変更を次リクエストで反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "target-mayaa-extends-switch";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutAHtmlPath = casePath + "layout-a.html";
+        String layoutAMayaaPath = casePath + "layout-a.mayaa";
+        String layoutBHtmlPath = casePath + "layout-b.html";
+        String layoutBMayaaPath = casePath + "layout-b.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+
+        String targetHtml = "<div id=\"content\">PAGE</div>";
+        String targetMayaa1 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/target-mayaa-extends-switch/layout-a.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String targetMayaa2 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/target-mayaa-extends-switch/layout-b.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String layoutAHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-a-default</div>
+                <footer>LAYOUT-A</footer>
+                </body></html>
+                """;
+        String layoutBHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-b-default</div>
+                <footer>LAYOUT-B</footer>
+                </body></html>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                </m:mayaa>
+                """;
+        String expected1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <footer>LAYOUT-A</footer>
+                </body></html>
+                """;
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <footer>LAYOUT-B</footer>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa1);
+        DynamicRegisteredSourceHolder.registerContents(layoutAHtmlPath, layoutAHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutAMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutBHtmlPath, layoutBHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutBMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa2);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void layoutMayaaのinsert定義変更を次リクエストで反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "layout-mayaa-update-detection";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+
+        String targetHtml = "<div id=\"content\">PAGE-CONTENT</div><div id=\"alt\">PAGE-ALT</div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/layout-mayaa-update-detection/layout.html">
+                    <m:doRender id="content" name="contentBody" />
+                    <m:doRender id="alt" name="altBody" />
+                </m:mayaa>
+                """;
+        String layoutHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                </body></html>
+                """;
+        String layoutMayaa1 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                </m:mayaa>
+                """;
+        String layoutMayaa2 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="altBody" replace="false" />
+                </m:mayaa>
+                """;
+        String expected1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE-CONTENT</div>
+                </body></html>
+                """;
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE-ALT</div>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa1);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa2);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void componentMayaaのdoRender定義変更を次リクエストで反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "component-mayaa-update-detection";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String componentHtmlPath = casePath + "component.html";
+        String componentMayaaPath = casePath + "component.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+
+        String targetHtml = "<div id=\"content\">PAGE</div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/component-mayaa-update-detection/layout.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String layoutHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                <div id="compSlot">layout-comp-default</div>
+                </body></html>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                    <m:insert id="compSlot" path="./component.html" replace="false" />
+                </m:mayaa>
+                """;
+        String componentHtml = "<div id=\"root1\">ONE</div><div id=\"root2\">TWO</div>";
+        String componentMayaa1 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:doRender id="root1" replace="false" />
+                </m:mayaa>
+                """;
+        String componentMayaa2 = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:doRender id="root2" replace="false" />
+                </m:mayaa>
+                """;
+        String expected1 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <div id="compSlot"><div id="root1">ONE</div></div>
+                </body></html>
+                """;
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <div id="compSlot"><div id="root2">TWO</div></div>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(componentHtmlPath, componentHtml);
+        DynamicRegisteredSourceHolder.registerContents(componentMayaaPath, componentMayaa1);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(componentMayaaPath, componentMayaa2);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void targetMayaaのextends有無の遷移を次リクエストで反映する(boolean useNewParser)
+            throws IOException, InterruptedException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "target-mayaa-extends-toggle";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String expected1Path = casePath + "expected1.html";
+        String expected2Path = casePath + "expected2.html";
+        String expected3Path = casePath + "expected3.html";
+
+        String targetHtml = "<div id=\"content\">PAGE</div>";
+        String targetMayaaNoExtends = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                </m:mayaa>
+                """;
+        String targetMayaaWithExtends = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        m:extends="/it-case/specification-life-cycle/target-mayaa-extends-toggle/layout.html">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String layoutHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                <footer>WITH-LAYOUT</footer>
+                </body></html>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                </m:mayaa>
+                """;
+        String expected1 = "<div id=\"content\">PAGE</div>";
+        String expected2 = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE</div>
+                <footer>WITH-LAYOUT</footer>
+                </body></html>
+                """;
+        String expected3 = "<div id=\"content\">PAGE</div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaaNoExtends);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expected1Path, expected1);
+
+        execAndVerify(targetHtmlPath, expected1Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaaWithExtends);
+        DynamicRegisteredSourceHolder.registerContents(expected2Path, expected2);
+
+        execAndVerify(targetHtmlPath, expected2Path, new LinkedHashMap<String, Object>());
+
+        Thread.sleep(5L);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaaNoExtends);
+        DynamicRegisteredSourceHolder.registerContents(expected3Path, expected3);
+
+        execAndVerify(targetHtmlPath, expected3Path, new LinkedHashMap<String, Object>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}

--- a/src/test/java/org/seasar/mayaa/impl/engine/EngineImplTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/engine/EngineImplTest.java
@@ -16,7 +16,11 @@
 package org.seasar.mayaa.impl.engine;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.seasar.mayaa.impl.CONST_IMPL;
 import org.seasar.mayaa.impl.cycle.CycleUtil;
 import org.seasar.mayaa.test.util.ManualProviderFactory;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 /**
  * @author Masataka Kurihara (Gluegent, Inc.)
@@ -110,6 +116,50 @@ public class EngineImplTest {
         ManualProviderFactory.HTTP_SERVLET_REQUEST.setPathInfo("/docs/test.html");
         CycleUtil.initialize(ManualProviderFactory.HTTP_SERVLET_REQUEST, ManualProviderFactory.HTTP_SERVLET_RESPONSE);
         assertFalse(engine.isPageRequested(), "3");
+    }
+
+    @Test
+    public void testDeprecatedSpecificationIsNotReturnedFromCache() {
+        EngineImpl engine = new EngineImpl();
+        String pageName = "/cache-validation-check";
+        String systemID = pageName + ".mayaa";
+
+        engine.createPageInstance(pageName);
+        assertNotNull(engine.findSpecificationFromCache(systemID));
+
+        engine.deprecateSpecification(systemID, false);
+        assertNull(engine.findSpecificationFromCache(systemID));
+
+        assertNotNull(engine.getPage(pageName));
+        assertNotNull(engine.findSpecificationFromCache(systemID));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void 同一リクエスト内でfindSpecificationFromCacheを繰り返してもisDeprecatedは初回のみ評価される() throws Exception {
+        EngineImpl engine = new EngineImpl();
+        String pageName = "/isDeprecated-call-count";
+        String systemID = pageName + ".mayaa";
+
+        // Spec を Caffeine キャッシュに登録
+        engine.createPageInstance(pageName);
+
+        // リクエストスコープを開始
+        CycleUtil.initialize(ManualProviderFactory.HTTP_SERVLET_REQUEST, ManualProviderFactory.HTTP_SERVLET_RESPONSE);
+
+        // 1回目: Caffeine から取得 → isDeprecated()評価あり → リクエストキャッシュへ投入
+        assertNotNull(engine.findSpecificationFromCache(systemID), "1回目は非-null");
+
+        // Caffeine キャッシュだけを無効化 (リクエストキャッシュはクリアしない)
+        Field specCacheField = EngineImpl.class.getDeclaredField("_specCache");
+        specCacheField.setAccessible(true);
+        Cache<String, ?> specCache = (Cache<String, ?>) specCacheField.get(engine);
+        specCache.invalidate(systemID);
+
+        // 2回目: Caffeine にはないがリクエストキャッシュが有効なため非-null で返る
+        // → isDeprecated()に届かず、リクエストキャッシュで短絡されたことを証明する
+        assertNotNull(engine.findSpecificationFromCache(systemID),
+                "2回目: Caffeineが空でもリクエストキャッシュから返るため非-null");
     }
 
 }


### PR DESCRIPTION
### 概要
`PageImpl`のSuperPage(レイアウト共有のファイル)キャッシュのstale問題※を根本的に修正し、Specificationの更新検知を正確化。併せて`EngineImpl`内での`isDeprecated`呼び出しの冗長実行を削減し、request-scope cacheを導入して効率化。

※stale問題
`PageImpl`が参照する m:extends属性が別のファイルパスを指すように更新されても、フィールドとして保持してしまっているSuperPageインスタンスを切り替える処理がなく、レイアウトが切り替わらない問題。

### 問題
1. ページスーパークラスの更新検知漏れ
  * `PageImpl`の`_superPage`など4つのフィールドキャッシュが、m:extends属性の更新時にstale状態のままになる
  * レイアウト変更後のリクエストで古いsuper情報に基づいたレンダリングが行われる
2. isDeprecated呼び出しの冗長実行 ( #83 )
  * `EngineImpl`の`createSpecificationInstance()`で無駄な二重チェック
  * 一回のリクエストの間にでも複数回の `isDeprecated()`が呼ばれていてリクエスト過程で内容が変わる可能性がある

### 修正内容
4つのコミットで段階的に修正：

1. EngineImplのrequest-scope cache導入
  * `findValidSpecificationFromCache()`追加：request内での重複検証回避
  * `getRequestValidSpecCache()`/`clearRequestValidSpecCache()`追加
  * Caffeine cache + request-scope cache の2層構造化
2. Specificationのfindメソッド再配置
  * `SpecificationUtil.findSpecification()`削除（ServiceCycle依存を廃止）
  * `EngineUtil.findCurrentSpecification()`追加（役割を明確化）
3. PageImplのsuper解決をEngine経由化
  * フィールドキャッシュ削除：`_superPage`, `_superSuffix`, `_superExtension`, `_superPrepared`
  * `SuperPageInfo`内部クラス追加（不変）
resolveSuperPageInfo()追加：毎回m:extends属性を読み直し
prepareSuper()削除
RenderUtilで1回呼び出しに最適化
4. ライフサイクル観点の結合テスト4ケース追加
SpecificationLifeCycleIntegrationTest.java新規作成
6テストケース × useNewParser 2値 = 12テスト

### テスト結果
✅ 全12テスト PASS

### 修正効果
* m:extends変更時の更新検知が確実に動作（staleキャッシュ排除）
* リクエスト内の重複Spec検証を排除（request-scope cache活用）
* isDeprecated()呼び出し削減. 
* Specの関心分離が明確化
