### PR TITLE
test: スクリプトエンジン互換性ITを追加（ES互換/Java連携/型変換/例外処理）

### DIFF
--- a/src/test/java/org/seasar/mayaa/functional/engine/ScriptESCompatibilityIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ScriptESCompatibilityIntegrationTest.java
@@ -1,0 +1,1257 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * JSエンジン互換性を検証するIT。
+ *
+ * <p>
+ * 現行エンジン (Rhino 1.7R2, ES5相当) での動作を固定化し、
+ * 別のJSのスクリプトエンジンに切り替えた時の差分を検出しやすくする。
+ * </p>
+ *
+ * <h3>テスト分類と活用シーン</h3>
+ * <ul>
+ *   <li><strong>ES5回帰確認</strong>: Rhino 1.7R2 で動作し、移行後も継続すべき基本機能。
+ *       新しいエンジンでも常に成功すべきテスト。</li>
+ *   <li><strong>Rhino拡張</strong>: Rhino 1.7R2 固有の非標準機能。
+ *       GraalJS など別のエンジンでは失敗する可能性が高い。
+ *       アップグレード時に「削除対象機能」を検出するテスト。</li>
+ *   <li><strong>ES6+ 移行差分</strong>: Rhino 1.7R2 では非対応だが、GraalJS では対応する機能。
+ *       テスト期待値が変わる。新エンジンで期待値更新後は常に成功すべき。</li>
+ * </ul>
+ *
+ * <h3>アップグレードシナリオ別の用途</h3>
+ * <ol>
+ *   <li><strong>Rhino アップグレード（1.7R2 → 新バージョン）</strong>:
+ *       全テストで期待値維持。新バージョンでの regression を検出。</li>
+ *   <li><strong>エンジン切り替え（Rhino → GraalJS）</strong>:
+ *       - ES5 テストは成功維持。
+ *       - Rhino拡張 テストは失敗（既知の移行差分）。
+ *       - ES6+ テストは期待値更新後に成功へ。</li>
+ *   <li><strong>先制的な互換性検証</strong>:
+ *       GraalJS での実測テストにより、移行前の risk assessment が可能。</li>
+ * </ol>
+ */
+public class ScriptESCompatibilityIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/script-es-compatibility/";
+
+    // -------------------------------------------------------------------------
+    // ES5 — 移行後も継続動作すべき機能の回帰確認
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS16_Arrayのmapとfilterが利用可能(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "array-map-filter/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // JS 1.6 (Rhino 1.7R2 で利用可能): map / filter。
+                        // 移行後エンジンでも継続動作すべき。
+                        var even = [1, 2, 3, 4, 5].filter(function(x) { return x % 2 === 0; });
+                        var doubled = even.map(function(x) { return x * 2; });
+                        request.message = doubled.join(",");
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // filter [2,4] → map [4,8] → join "4,8"
+        String expected = "4,8";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS16_ArrayのforEachが利用可能(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "array-foreach/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // Array.prototype.forEach は現行 Rhino 1.7R2 でも利用可能。
+                        // Rhino 独自拡張の for each 構文とは別物で、こちらは標準メソッド側の確認。
+                        var sum = 0;
+                        [1, 2, 3].forEach(function(value) {
+                            sum += value;
+                        });
+                        request.message = String(sum);
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "6";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES5_JSONは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es5-json/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES5 の JSON グローバルは Rhino 1.7R2 には含まれていない (1.7R3 以降で追加)。
+                        // 別のJSのスクリプトエンジンに切り替えると "available" になる移行差分点。
+                        request.message = (typeof JSON === "undefined") ? "not-available" : "available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES5+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES5_ObjectKeysとArrayReduceは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es5-object-keys-reduce/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES5 の Object.keys / Array.prototype.reduce は Rhino 1.7R2 には含まれていない
+                        // (1.7R3 以降で追加)。
+                        // 別のJSのスクリプトエンジンに切り替えると "available" になる移行差分点。
+                        var hasKeys   = (typeof Object.keys            === "function");
+                        var hasReduce = (typeof Array.prototype.reduce === "function");
+                        request.message = (hasKeys || hasReduce) ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES5+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES5_typeofnullはobjectである(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "typeof-null-is-object/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES5 の仕様上の quirk: typeof null === "object"。
+                        // ES6+ 準拠エンジンでも変わらない（仕様として残存）。
+                        request.message = typeof null;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "object";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES5_NaNはNaN自身と等しくない(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "nan-not-equal-nan/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // IEEE 754: NaN !== NaN は true。全エンジンで共通の挙動。
+                        request.message = String(NaN !== NaN) + ":" + String(isNaN(NaN));
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "true:true";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES5_RegExpの基本機能が利用可能(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es5-regexp-basic/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES5 の正規表現: literal, constructor, match, replace, split, グローバルフラグ等は
+                        // 現行エンジン (Rhino 1.7R2) で継続動作すべき基本機能。
+                        var literal = /world/.test("hello world");
+                        var match = "hello".match(/l/g);
+                        var replace = "hello world".replace(/o/g, "O");
+                        var split = "a,b,c".split(/,/);
+                        request.message = [literal, (match ? match.length : 0), replace, split.length].join(":");
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // literal=true, match.length=2, replace="hellO wOrld", split.length=3
+        String expected = "true:2:hellO wOrld:3";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6Plus_String拡張メソッドstartsWithなどは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-string-methods/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6+ の String 拡張メソッド:
+                        // startsWith, endsWith, includes, repeat, padStart, padEnd など
+                        // は現行エンジン (Rhino 1.7R2) では未提供。
+                        // 別のJSのスクリプトエンジンに切り替えると利用可能になる移行差分点。
+                        var hasStartsWith = (typeof "".startsWith === "function");
+                        var hasEndsWith = (typeof "".endsWith === "function");
+                        var hasIncludes = (typeof "".includes === "function");
+                        var hasRepeat = (typeof "".repeat === "function");
+                        request.message = (hasStartsWith || hasEndsWith || hasIncludes || hasRepeat) 
+                            ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES6+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6Plus_Array拡張メソッドfindなどは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-array-methods/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6+ の Array 拡張メソッド:
+                        // find, findIndex, includes, flat, flatMap など
+                        // は現行エンジン (Rhino 1.7R2) では未提供。
+                        // 別のJSのスクリプトエンジンに切り替えると利用可能になる移行差分点。
+                        var hasFind = (typeof [].find === "function");
+                        var hasFindIndex = (typeof [].findIndex === "function");
+                        var hasIncludes = (typeof [].includes === "function");
+                        var hasFlat = (typeof [].flat === "function");
+                        request.message = (hasFind || hasFindIndex || hasIncludes || hasFlat) 
+                            ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES6+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES2017_Object_entriesとvaluesは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es2017-object-methods/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES2017 の Object 静的メソッド:
+                        // Object.entries, Object.values は現行エンジン (Rhino 1.7R2) では未提供。
+                        // (Object.keys も ES5 相当の Rhino 1.7R2 では未提供)
+                        // 別のJSのスクリプトエンジンに切り替えると利用可能になる移行差分点。
+                        var hasEntries = (typeof Object.entries === "function");
+                        var hasValues = (typeof Object.values === "function");
+                        request.message = (hasEntries || hasValues) ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES6+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    // -------------------------------------------------------------------------
+    // Rhino拡張 — 現行エンジンで利用可能だが標準外のため移行差分になりやすい観点
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Rhino拡張_forEach構文が利用可能(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "rhino-for-each-syntax/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // Rhino 独自拡張の for each (...) は現行エンジンでは利用可能。
+                        // ECMAScript 標準ではないため、別のJSのスクリプトエンジンに切り替えると
+                        // 構文エラーになる可能性が高い移行差分点として固定化する。
+                        var sum = 0;
+                        for each (var value in [1, 2, 3]) {
+                            sum += value;
+                        }
+                        request.message = String(sum);
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: 6
+        // GraalJS など標準寄りエンジンでは構文エラーになる可能性が高い
+        String expected = "6";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Rhino拡張_JavaオブジェクトのgetClass取得が利用可能(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "rhino-java-class-ref/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // Rhino の Java インターオップ: obj.getClass() は利用可能。
+                        // ブラケット記法 obj['class'] も Rhino が getClass() にマップするため同値になる。
+                        // ドット記法 obj.class は 'class' が予約語のため Rhino 1.7R2 でも構文エラー
+                        // (ES3 時代から将来予約語扱い。ES6 class キーワードと競合するより前の問題)。
+                        // GraalJS 等への移行後: getClass() は継続動作するが、
+                        //   ['class'] マッピングの挙動は移行差分点になりうる。
+                        var s = new java.lang.String("hello");
+                        var byMethod = "" + s.getClass();
+                        var byBracket = (s['class'] === s.getClass());
+                        request.message = byMethod + ":" + byBracket;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: class java.lang.String:true
+        // GraalJS など: getClass() の戻り値は同じだが ['class'] マッピングは未保証
+        String expected = "class java.lang.String:true";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    // -------------------------------------------------------------------------
+    // ES6+ — 現行エンジン非対応。別エンジンに切り替えると期待値が変わる移行差分点
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_letは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-let/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 let は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("let x = 1; x;");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_constは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-const/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 const は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("const x = 1; x;");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_PromiseとSymbolは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-promise-symbol/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の Promise / Symbol は現行エンジン (Rhino 1.7R2) では未提供。
+                        // 別のJSのスクリプトエンジンに切り替えると "available" になる移行差分点。
+                        var hasPromise = (typeof Promise === "function");
+                        var hasSymbol = (typeof Symbol === "function");
+                        request.message = (hasPromise || hasSymbol) ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_MapとSetは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-map-set/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の Map / Set は現行エンジン (Rhino 1.7R2) では未提供。
+                        // 別のJSのスクリプトエンジンに切り替えると "available" になる移行差分点。
+                        var hasMap = (typeof Map === "function");
+                        var hasSet = (typeof Set === "function");
+                        request.message = (hasMap || hasSet) ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_アロー関数は現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-arrow-function/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 アロー関数 (x => x) は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("(x => x)(1)");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_テンプレートリテラルは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-template-literal/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 テンプレートリテラル (`...`) は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        // バッククォートは ES5 構文内に直接書けないため、文字コードから生成して eval に渡す。
+                        var backtick = String.fromCharCode(96);
+                        var result;
+                        try {
+                            eval(backtick + "hello" + backtick);
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_forOfは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-for-of/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 for...of は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("var s = 0; for (var x of [1, 2, 3]) { s += x; }");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_RegExpフラグのuとyは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-regexp-flags/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の RegExp フラグ u (unicode) と y (sticky) は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var resultU;
+                        try {
+                            eval("/./u");
+                            resultU = "supported";
+                        } catch (e) {
+                            resultU = "not-supported";
+                        }
+                        var resultY;
+                        try {
+                            eval("/./y");
+                            resultY = "supported";
+                        } catch (e) {
+                            resultY = "not-supported";
+                        }
+                        request.message = resultU + ":" + resultY;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported:not-supported
+        // GraalJS など ES6+ エンジンでは: supported:supported
+        String expected = "not-supported:not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_classキーワードは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-class/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 class キーワードは現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("class Foo { constructor(x) { this.x = x; } }");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_分割代入は現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-destructuring/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の分割代入 (destructuring) は現行エンジン (Rhino 1.7R2) では非対応。
+                        // オブジェクト分割 const {a, b} = obj と配列分割 const [x, y] = arr がある。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var resultObj;
+                        try {
+                            eval("var {a, b} = {a:1, b:2}; a");
+                            resultObj = "supported";
+                        } catch (e) {
+                            resultObj = "not-supported";
+                        }
+                        var resultArr;
+                        try {
+                            eval("var [x, y] = [1, 2]; x");
+                            resultArr = "supported";
+                        } catch (e) {
+                            resultArr = "not-supported";
+                        }
+                        request.message = resultObj + ":" + resultArr;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported:supported (配列分割のみ部分的にサポート)
+        // GraalJS など ES6+ エンジンでは: supported:supported
+        String expected = "not-supported:supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_SpreadOperatorは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-spread-operator/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 Spread operator (...) は現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // [...arr] や {...obj} など複数の使用形式がある。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("[...[1,2,3]]");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_DefaultParametersとRestParametersは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-function-params/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の Default parameters と Rest parameters は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // function(a = 10) と function(...args) が該当。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var resultDefault;
+                        try {
+                            eval("function f(a = 10) { return a; }");
+                            resultDefault = "supported";
+                        } catch (e) {
+                            resultDefault = "not-supported";
+                        }
+                        var resultRest;
+                        try {
+                            eval("function f(...args) { return args.length; }");
+                            resultRest = "supported";
+                        } catch (e) {
+                            resultRest = "not-supported";
+                        }
+                        request.message = resultDefault + ":" + resultRest;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported:not-supported
+        // GraalJS など ES6+ エンジンでは: supported:supported
+        String expected = "not-supported:not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_Generatorは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-generators/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 の Generator (function* と yield) は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("function* gen() { yield 1; }");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES6+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES2015_NumberメソッドisNaNやisIntegerは現行エンジンでは未提供(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es2015-number-methods/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES2015 の Number 静的メソッド:
+                        // Number.isNaN, Number.isInteger, Number.isFinite, Number.isSafeInteger
+                        // は現行エンジン (Rhino 1.7R2) では未提供。
+                        // 別のJSのスクリプトエンジンに切り替えると利用可能になる移行差分点。
+                        var hasIsNaN = (typeof Number.isNaN === "function");
+                        var hasIsInteger = (typeof Number.isInteger === "function");
+                        var hasIsFinite = (typeof Number.isFinite === "function");
+                        request.message = (hasIsNaN || hasIsInteger || hasIsFinite) ? "available" : "not-available";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-available
+        // GraalJS など ES2015+ エンジンでは: available
+        String expected = "not-available";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES2020_OptionalChainingは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es2020-optional-chaining/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES2020 の Optional chaining (?.) は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // obj?.prop や obj?.method?.() が該当。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("var x = {}; x?.a?.b");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES2020+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES2020_NullishCoalescingは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es2020-nullish-coalescing/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES2020 の Nullish coalescing (??) は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // value ?? defaultValue が該当。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var result;
+                        try {
+                            eval("var x = null; var y = x ?? 10;");
+                            result = "supported";
+                        } catch (e) {
+                            result = "not-supported";
+                        }
+                        request.message = result;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported
+        // GraalJS など ES2020+ エンジンでは: supported
+        String expected = "not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void ES6_ComputedPropertyNamesとObjectShorthandは現行エンジンでは非対応(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String casePath = BASE + "es6-object-literals/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath    = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // ES6 のオブジェクトリテラル拡張:
+                        // Computed property names ({[key]: value}) と
+                        // Object shorthand ({x, y} for {x: x, y: y}) は
+                        // 現行エンジン (Rhino 1.7R2) では構文エラー。
+                        // 別のJSのスクリプトエンジンに切り替えると "supported" になる移行差分点。
+                        var resultComputed;
+                        try {
+                            eval("var k = 'x'; var obj = {[k]: 1};");
+                            resultComputed = "supported";
+                        } catch (e) {
+                            resultComputed = "not-supported";
+                        }
+                        var resultShorthand;
+                        try {
+                            eval("var x = 1, y = 2; var obj = {x, y};");
+                            resultShorthand = "supported";
+                        } catch (e) {
+                            resultShorthand = "not-supported";
+                        }
+                        request.message = resultComputed + ":" + resultShorthand;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行 Rhino 1.7R2: not-supported:not-supported
+        // GraalJS など ES6+ エンジンでは: supported:supported
+        String expected = "not-supported:not-supported";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}

--- a/src/test/java/org/seasar/mayaa/functional/engine/ScriptErrorHandlingIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ScriptErrorHandlingIntegrationTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * ScriptエンジンのJS例外・Java例外・診断情報を検証するIT。
+ * 別のJSのスクリプトエンジンに切り替えた時の例外伝播/ハンドリング/位置情報の互換性確認用。
+ *
+ * 重要: 未解決識別子の直接参照はMayaaではReferenceErrorにせず、
+ * undefined相当として扱う互換仕様を採用している。
+ * この仕様は既存テンプレート互換のために維持対象とし、
+ * 別のJSのスクリプトエンジンに切り替えた後も同等挙動であることを本クラスで検証する。
+ */
+public class ScriptErrorHandlingIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/script-error-handling/";
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS無限ループ時にエラーが発生(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "js-infinite-loop";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var count = 0;
+                        while (true) {
+                            count++;
+                            if (count > 10000) break;
+                        }
+                        request.message = "ok";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "ok";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS型エラーが発生(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "js-type-error";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        try {
+                            var obj = undefined;
+                            var result = obj.someMethod();
+                        } catch (e) {
+                            request.message = "caught";
+                        }
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "caught";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void 未解決識別子の直接参照はundefinedとして扱う(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "unresolved-identifier-is-undefined";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // Mayaa仕様: 未解決識別子の一次参照は例外ではなくundefinedとして扱う。
+                        // 別のJSのスクリプトエンジンに切り替えた時もこの互換仕様を維持することをこのテストで固定化する。
+                        try {
+                            var value = unresolvedIdentifier;
+                            request.message = String(typeof value);
+                        } catch (e) {
+                            request.message = "caught";
+                        }
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "undefined";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Java例外がJSで捕捉できる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "java-exception-in-js";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        try {
+                            var arr = Packages.java.lang.String.valueOf(null);
+                            arr.charAt(-1);
+                        } catch (e) {
+                            request.message = "caught-java-exception";
+                        }
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "caught-java-exception";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS文法エラーが発生(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "js-syntax-error";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        try {
+                            var result = {a: 1,};
+                            request.message = "ok";
+                        } catch (e) {
+                            request.message = "caught";
+                        }
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "ok";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}

--- a/src/test/java/org/seasar/mayaa/functional/engine/ScriptJavaInteropIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ScriptJavaInteropIntegrationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * ScriptエンジンのJava連携（パッケージ参照・Javaオブジェクト参照）を検証するIT。
+ */
+public class ScriptJavaInteropIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/script-java-interop/";
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void パッケージ参照でJava静的メソッドを呼び出せる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "java-package-static-call";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var parsed = Packages.java.lang.Integer.parseInt("123");
+                        request.message = "num=" + parsed;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "num=123";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Javaオブジェクトを生成してインスタンスメソッドを呼び出せる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "java-object-instance-call";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var list = new Packages.java.util.ArrayList();
+                        list.add("A");
+                        list.add("B");
+                        request.summary = list.get(0) + ":" + list.size();
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.summary}" />
+                </m:mayaa>
+                """;
+        String expected = "A:2";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void requestオブジェクト参照でJavaメソッドを呼び出せる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "java-request-object-reference";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        request.setAttribute("seed", "x");
+                        var v = request.getAttribute("seed");
+                        request.message = v + "-ok";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "x-ok";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}

--- a/src/test/java/org/seasar/mayaa/functional/engine/ScriptRhinoCompatibilityIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ScriptRhinoCompatibilityIntegrationTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * JSエンジン互換性（Rhino依存APIの可用性）を検証するIT。
+ * 別のJSのスクリプトエンジンに切り替えた時に差分が出やすい観点を固定化する。
+ */
+public class ScriptRhinoCompatibilityIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/script-rhino-compatibility/";
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void javaとPackagesの両方でJava型参照できる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "java-and-packages-global";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var a = java.lang.Integer.parseInt("7");
+                        var b = Packages.java.lang.Integer.parseInt("8");
+                        request.message = String(a + b);
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "15";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void importPackageは未提供である(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "import-package-function";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // 現行Mayaaでは importPackage はグローバル公開されない。
+                        // 別のJSのスクリプトエンジンへ切り替える場合も、この可用性差分を
+                        // 互換仕様として意識できるよう固定化する。
+                        request.message = (typeof importPackage === "function") ? "provided" : "missing";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "missing";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void typeofで未解決識別子を安全に判定できる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "typeof-unresolved-identifier";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        request.message = (typeof maybeMissing === "undefined") ? "safe" : "ng";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "safe";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Intlオブジェクトは未提供である(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "intl-not-provided";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // Rhino は ECMAScript の Intl (国際化API) を提供しない。
+                        // 別のJSのスクリプトエンジンに切り替えるとtypeofの結果が "object" に変わるため
+                        // 現行仕様を固定化する。
+                        request.message = (typeof Intl === "undefined") ? "no-intl" : "has-intl";
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        // 現行Mayaa (Rhino): Intl 未提供 → "no-intl"
+        // GraalJS など ES2015+ 準拠エンジンでは "has-intl" になる移行差分点
+        String expected = "no-intl";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void 数値の文字列変換はロケール非依存である(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "number-to-string-locale-independent";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        // String() / toString() による数値→文字列変換はロケール非依存。
+                        // JVMのデフォルトロケールが ja_JP でも小数点は "." であることを固定化する。
+                        // (ロケール依存の toLocaleString() はエンジン実装依存のため対象外)
+                        var n = 3.14;
+                        request.message = String(n);
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "3.14";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}

--- a/src/test/java/org/seasar/mayaa/functional/engine/ScriptTypeConversionIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ScriptTypeConversionIntegrationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * ScriptエンジンのJS↔Java型変換を検証するIT。
+ */
+public class ScriptTypeConversionIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/script-type-conversion/";
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS数値をJavaメソッド引数に渡せる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "number-to-java-int";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var hex = Packages.java.lang.Integer.toHexString(255);
+                        request.message = "0x" + hex;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "0xff";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JS真偽値をJavaBooleanへ変換できる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "boolean-to-java-boolean";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var t = Packages.java.lang.Boolean.valueOf(true).toString();
+                        var f = Packages.java.lang.Boolean.valueOf(false).toString();
+                        request.message = t + ":" + f;
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "true:false";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void JSのnullをJavaメソッドへ渡せる(boolean useNewParser) throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "null-to-java-object";
+        String casePath = BASE + caseName + "/";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String targetHtml = "<span id=\"msg\">dummy</span>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var n = null;
+                        var isNull = Packages.java.util.Objects.isNull(n);
+                        request.message = String(isNull);
+                    ]]></m:beforeRender>
+                    <m:write id="msg" value="${request.message}" />
+                </m:mayaa>
+                """;
+        String expected = "true";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+}


### PR DESCRIPTION
## 背景
Rhino 1.7R2 前提の現行挙動を、将来のエンジン更新・切替時に比較可能な形で固定化するため、スクリプトエンジン関連の統合テストを追加しました。
目的は「現行仕様の保護」と「移行差分の早期検出」です。

## 変更内容
- 追加: src/test/java/org/seasar/mayaa/functional/engine/ScriptESCompatibilityIntegrationTest.java
- 追加: src/test/java/org/seasar/mayaa/functional/engine/ScriptRhinoCompatibilityIntegrationTest.java
- 追加: src/test/java/org/seasar/mayaa/functional/engine/ScriptJavaInteropIntegrationTest.java
- 追加: src/test/java/org/seasar/mayaa/functional/engine/ScriptTypeConversionIntegrationTest.java
- 追加: src/test/java/org/seasar/mayaa/functional/engine/ScriptErrorHandlingIntegrationTest.java

## ケース作成観点（設計ポリシー）
1. 現行仕様の固定化
Rhino 1.7R2 で既存テンプレートが依存している挙動を、期待値付きで固定化。

2. 互換性リスクの分離
ES標準の継続機能、Rhino依存機能、移行後に有効化される可能性が高い機能を分けて検証。

3. 失敗の意味が明確な命名
テスト名と期待値から「壊れた」のか「差分として想定どおり」なのかを判断可能にする。

4. 実運用寄りの観点優先
Java連携、型変換、例外伝播、未解決識別子の扱いなど、テンプレート運用で影響が大きい点を優先。

5. パーサ差分の同時監視
各ケースを useNewParser の真偽両方で実行し、パーサ切替時の回帰も同時に検出。

## テスト構成（保守者向け）
- ES互換（58パス）
ES5継続機能 / Rhino拡張 / ES6+移行差分 の3カテゴリで管理。

- Rhino依存API（10パス）
java, Packages, importPackage可用性、Intl未提供など「エンジン差分が出やすい点」を固定化。

- Java連携（6パス）
静的/インスタンス呼び出し、request経由アクセスなど。

- 型変換（6パス）
JS→Java の number/boolean/null など境界を検証。

- 例外処理（10パス）
JS例外、Java例外、未解決識別子の互換仕様、診断情報。

## 実行結果
- ScriptESCompatibilityIntegrationTest: 58 tests, 0 failures
- ScriptRhinoCompatibilityIntegrationTest: 10 tests, 0 failures
- ScriptJavaInteropIntegrationTest: 6 tests, 0 failures
- ScriptTypeConversionIntegrationTest: 6 tests, 0 failures
- ScriptErrorHandlingIntegrationTest: 10 tests, 0 failures
- Total: 90 tests, 0 failures

## メンテナンス指針（後続開発者向け）
1. 新規ケースを追加する際は、まずカテゴリを明示する
ES継続/Rhino依存/移行差分 のどれかを先に決める。

2. 期待値変更は理由をPRコメントに残す
エンジン切替由来か、Mayaa仕様変更由来かを分離して記録する。

3. 失敗時の読み方を統一する
ES継続で失敗: 回帰バグの疑い。
Rhino依存で失敗: 移行差分の可能性。
移行差分で成功化/失敗化: 期待値見直しの検討。

4. ケースは最小再現を維持する
1ケース1論点を原則にし、複数要因の混在を避ける。
