### PR TITLE
fix: ParentSpecificationResolver 使用時に beforeRender/afterRender が親仕様チェーン順で実行されない不具合を修正

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
@@ -15,9 +15,11 @@
  */
 package org.seasar.mayaa.impl.engine;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.seasar.mayaa.cycle.ServiceCycle;
 import org.seasar.mayaa.cycle.script.CompiledScript;
@@ -42,6 +44,9 @@ import org.seasar.mayaa.source.SourceDescriptor;
  * @author Masataka Kurihara (Gluegent, Inc.)
  */
 public class RenderUtil implements CONST_IMPL {
+
+    private record SuperPageInfo(Page page, String suffix, String extension) {
+    }
 
     private static final ProcessStatus SKIP_BODY =
             ProcessStatus.SKIP_BODY;
@@ -330,22 +335,20 @@ public class RenderUtil implements CONST_IMPL {
                 SpecificationUtil.startScope(variables);
                 SpecificationUtil.execEvent(page, QM_BEFORE_RENDER);
             }
-            Template template =
-                getTemplate(requestedSuffix, page, suffix, extension);
+
+            SuperPageInfo superInfo = resolveSuperPageInfo(page);
+            if (fireEvent && superInfo.page == null) {
+                executeBeforeRenderOnAllParentSpecifications(page, pageStack);
+            }
+
+            Template template = getTemplate(requestedSuffix, page, suffix, extension);
             if (template != null) {
                 // LIFO access
                 templateStack.add(0, template);
             }
-            if (page instanceof PageImpl) {
-                PageImpl.SuperPageInfo superInfo = ((PageImpl) page).resolveSuperPageInfo();
-                suffix = superInfo.suffix;
-                extension = superInfo.extension;
-                page = superInfo.page;
-            } else {
-                suffix = page.getSuperSuffix();
-                extension = page.getSuperExtension();
-                page = page.getSuperPage();
-            }
+            suffix = superInfo.suffix;
+            extension = superInfo.extension;
+            page = superInfo.page;
             variables = null;
         } while(page != null);
         ProcessStatus ret = null;
@@ -357,13 +360,43 @@ public class RenderUtil implements CONST_IMPL {
         }
         if (fireEvent) {
             for (int i = 0; i < pageStack.size(); i++) {
-                page = (Page) pageStack.get(i);
-                saveToCycle(page);
-                SpecificationUtil.execEvent(page, QM_AFTER_RENDER);
+                Page p = pageStack.get(i);
+                saveToCycle(p);
+                SpecificationUtil.execEvent(p, QM_AFTER_RENDER);
                 SpecificationUtil.endScope();
             }
         }
         return ret;
+    }
+
+    private static SuperPageInfo resolveSuperPageInfo(Page page) {
+        if (page == null) {
+            throw new IllegalArgumentException();
+        }
+        if (page instanceof PageImpl) {
+            PageImpl.SuperPageInfo pageImplInfo = ((PageImpl) page).resolveSuperPageInfo();
+            return new SuperPageInfo(pageImplInfo.page, pageImplInfo.suffix, pageImplInfo.extension);
+        }
+        return new SuperPageInfo(page.getSuperPage(), page.getSuperSuffix(), page.getSuperExtension());
+    }
+
+    private static void executeBeforeRenderOnAllParentSpecifications(Page basePage, List<Page> pageStack) {
+        if (basePage == null || pageStack == null) {
+            throw new IllegalArgumentException();
+        }
+        Set<Specification> visited = new HashSet<>();
+        visited.add(basePage);
+        Specification defaultSpec = SpecificationUtil.getDefaultSpecification();
+
+        Specification parent = EngineUtil.getParentSpecification(basePage);
+        while (parent != null && !parent.getSystemID().equals(defaultSpec.getSystemID()) && visited.add(parent)) {
+            if (parent instanceof Page) {
+                pageStack.add(0, (Page) parent);
+            }
+            SpecificationUtil.startScope(null);
+            SpecificationUtil.execEvent(parent, QM_BEFORE_RENDER);
+            parent = EngineUtil.getParentSpecification(parent);
+        }
     }
 
 }

--- a/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.engine.Engine;
+import org.seasar.mayaa.engine.Page;
+import org.seasar.mayaa.engine.Template;
+import org.seasar.mayaa.engine.specification.ParentSpecificationResolver;
+import org.seasar.mayaa.engine.specification.Specification;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.ParameterAwareImpl;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.cycle.CycleUtil;
+import org.seasar.mayaa.impl.engine.specification.SpecificationUtil;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.provider.ProviderUtil;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * ParentSpecificationResolver を差し替えた場合の親連鎖解決と
+ * beforeRender/afterRender 実行順を検証するIT。
+ */
+public class ParentSpecificationResolverIntegrationTest extends EngineTestBase {
+
+    private ParentSpecificationResolver originalResolver;
+
+    @Test
+    public void デフォルトParentSpecificationResolverはPageに対してdefaultSpecificationを返す() {
+        String caseRoot = "/it-case/parent-specification-resolver/default-resolver";
+        String targetHtmlPath = caseRoot + "/target.html";
+        String targetMayaaPath = caseRoot + "/target.mayaa";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, "<div id=\"root\">dummy</div>");
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<m:mayaa xmlns:m=\"http://mayaa.seasar.org\"></m:mayaa>");
+
+        exec(createRequest(targetHtmlPath), new LinkedHashMap<String, Object>());
+
+        ParentSpecificationResolver resolver = getServiceProvider().getParentSpecificationResolver();
+        Page page = getPage();
+
+        assertSame(SpecificationUtil.getDefaultSpecification(), resolver.getParentSpecification(page));
+    }
+
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void 親仕様を複数段返し最後にケース専用defaultページを返す場合にbeforeAfterRenderが親連鎖順で実行される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/multi-parent-chain";
+        String targetHtmlPath = caseRoot + "/target.html";
+        String targetMayaaPath = caseRoot + "/target.mayaa";
+        String parent1HtmlPath = caseRoot + "/parent1.html";
+        String parent1MayaaPath = caseRoot + "/parent1.mayaa";
+        String parent2HtmlPath = caseRoot + "/parent2.html";
+        String parent2MayaaPath = caseRoot + "/parent2.mayaa";
+        String defaultMayaaPath = caseRoot + "/default.mayaa";
+        String expectedPath = caseRoot + "/expected.html";
+
+        String targetHtml = "<div id=\"root\"><span id=\"chain\">dummy</span></div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        appendBefore("T");
+                    ]]></m:beforeRender>
+                    <m:write id="chain" value="${chain.join('>')}" />
+                    <m:afterRender><![CDATA[
+                        application.parentChainTrace = application.parentChainTrace + "|A-T";
+                    ]]></m:afterRender>
+                </m:mayaa>
+                """;
+        String parent1Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        appendBefore("P1");
+                    ]]></m:beforeRender>
+                    <m:afterRender><![CDATA[
+                        application.parentChainTrace = application.parentChainTrace + "|A-P1";
+                    ]]></m:afterRender>
+                </m:mayaa>
+                """;
+        String parent2Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        appendBefore("P2");
+                    ]]></m:beforeRender>
+                    <m:afterRender><![CDATA[
+                        application.parentChainTrace = application.parentChainTrace + "|A-P2";
+                    ]]></m:afterRender>
+                </m:mayaa>
+                """;
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.parentChainTrace = "";
+                        var chain = [];
+                        function appendBefore(marker) {
+                            chain.push(marker);
+                            application.parentChainTrace = application.parentChainTrace + "|B-" + marker;
+                        }
+                        appendBefore("D");
+                    ]]></m:beforeRender>
+                    <m:afterRender><![CDATA[
+                        application.parentChainTrace = application.parentChainTrace + "|A-D";
+                    ]]></m:afterRender>
+                </m:mayaa>
+                """;
+        String expected = "<div id=\"root\">D&gt;T&gt;P1&gt;P2</div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(parent1HtmlPath, "<div id=\"parent1\"></div>");
+        DynamicRegisteredSourceHolder.registerContents(parent1MayaaPath, parent1Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(parent2HtmlPath, "<div id=\"parent2\"></div>");
+        DynamicRegisteredSourceHolder.registerContents(parent2MayaaPath, parent2Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath, defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        originalResolver = getServiceProvider().getParentSpecificationResolver();
+        getServiceProvider().setParentSpecificationResolver(
+                new ChainParentSpecificationResolver(originalResolver, caseRoot));
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
+
+        assertEquals("|B-D|B-T|B-P1|B-P2|A-P2|A-P1|A-T|A-D",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("parentChainTrace"));
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (originalResolver != null) {
+            getServiceProvider().setParentSpecificationResolver(originalResolver);
+            originalResolver = null;
+        }
+        getServiceProvider().getEngine().setParameter("defaultSpecification", "/default.mayaa");
+        // Ensure next tests rebuild global default from regular resources.
+        SpecificationUtil.getDefaultSpecification().deprecate();
+        DynamicRegisteredSourceHolder.unregisterAll();
+        DiagnosticEventBuffer.clear();
+    }
+
+    private static final class ChainParentSpecificationResolver extends ParameterAwareImpl
+            implements ParentSpecificationResolver {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ParentSpecificationResolver fallback;
+        private final String caseRoot;
+
+        private ChainParentSpecificationResolver(ParentSpecificationResolver fallback, String caseRoot) {
+            this.fallback = fallback;
+            this.caseRoot = caseRoot;
+        }
+
+        @Override
+        public Specification getParentSpecification(Specification spec) {
+            if (spec instanceof Template) {
+                return ((Template) spec).getPage();
+            }
+            if (!(spec instanceof Page)) {
+                return null;
+            }
+
+            String pageName = ((Page) spec).getPageName();
+            Engine engine = ProviderUtil.getEngine();
+            if ((caseRoot + "/target").equals(pageName)) {
+                return engine.getPage(caseRoot + "/parent1");
+            }
+            if ((caseRoot + "/parent1").equals(pageName)) {
+                return engine.getPage(caseRoot + "/parent2");
+            }
+            if ((caseRoot + "/parent2").equals(pageName)) {
+                return SpecificationUtil.getDefaultSpecification();
+            }
+            if (fallback != null) {
+                return fallback.getParentSpecification(spec);
+            }
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
## 概要

`ParentSpecificationResolver` をカスタム実装で差し替えた場合に、Resolver が返す中間親ページの `beforeRender` / `afterRender` イベントが実行されない不具合を修正します。

## 背景：beforeRender/afterRender の実行構造

`beforeRender`/`afterRender` の実行は、2つの仕組みが分担しています。

| 実行主体 | 担当 |
|---|---|
| `EngineImpl` | `default.mayaa` の `beforeRender`/`afterRender`（リクエスト全体をラップ） |
| `RenderUtil.renderPage()` do…while ループ | `m:extends` で宣言した SuperPage チェーン各ページの `beforeRender`/`afterRender` |

標準の `m:extends` によるレイアウト継承では、これらが機能していたため問題はありませんでした。

## 不具合内容

`RenderUtil.renderPage()` の do…while ループは `page.getSuperPage()`（= `m:extends` 属性の値）を使って親チェーンを辿ります。カスタム `ParentSpecificationResolver` が `m:extends` を使わずに独自の多段親チェーン（例: target → parent1 → parent2）を定義した場合、`getSuperPage()` は最初のループで即 `null` を返すため、**中間親ページ（parent1・parent2）の `beforeRender`/`afterRender` を実行する仕組みが存在しませんでした。**

**期待される実行順**（[描画前後のスクリプトのドキュメント](https://seasarorg.github.io/mayaa-site/docs/before_render/)より）：
```
beforeRender: default → parent2 → parent1 → target
afterRender:  target → parent1 → parent2 → default
```

**実際の実行順（修正前）**：
```
beforeRender: default → target のみ（中間親の beforeRender が未実行）
afterRender:  target → default のみ（中間親の afterRender が未実行）
```

## 修正内容

- `SuperPageInfo` を `RenderUtil` 内の private record として定義し `PageImpl` への依存を排除（整理）
- `executeBeforeRenderOnAllParentSpecifications()` を追加：
  - `EngineUtil.getParentSpecification()` を用いて `ParentSpecificationResolver` 経由で親仕様チェーンを辿る
  - `default.mayaa` に達したところで停止（`EngineImpl` との `beforeRender` 二重実行を回避）
  - 訪問済みセット（`HashSet`）による循環参照防止
  - 対象ページを `pageStack` に積むことで、`afterRender` も既存の LIFO 順で正しく実行される

## テスト

- `ParentSpecificationResolverIntegrationTest` を新規追加：
  - デフォルト Resolver の動作確認
  - 多段親チェーン（target → parent1 → parent2 → default）での beforeRender/afterRender 実行順検証（`|B-D|B-T|B-P1|B-P2|A-P2|A-P1|A-T|A-D` の順を確認）

## 関連ドキュメント

- [描画前後のスクリプト (beforeRender / afterRender)](https://seasarorg.github.io/mayaa-site/docs/before_render/) — 実行順の仕様
- [ページ共通の設定 (default.mayaa)](https://seasarorg.github.io/mayaa-site/docs/default/) — default.mayaa の役割
- [エンジンの設定 — parentSpecificationResolver](https://seasarorg.github.io/mayaa-site/docs/settings/) — ParentSpecificationResolver のカスタマイズ方法