### PR TITLE
fix: テンプレートビルド中に m:extends が設定される場合に初回リクエストでレイアウトが反映されない不具合を修正

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
@@ -336,16 +336,22 @@ public class RenderUtil implements CONST_IMPL {
                 SpecificationUtil.execEvent(page, QM_BEFORE_RENDER);
             }
 
-            SuperPageInfo superInfo = resolveSuperPageInfo(page);
-            if (fireEvent && superInfo.page == null) {
-                executeBeforeRenderOnAllParentSpecifications(page, pageStack);
-            }
-
             Template template = getTemplate(requestedSuffix, page, suffix, extension);
             if (template != null) {
                 // LIFO access
                 templateStack.add(0, template);
             }
+
+            // テンプレートビルド後に resolveSuperPageInfo を呼ぶ。
+            // setupExtends のオーバーライド等でテンプレートビルド中（afterBuild）に
+            // ページの mayaaNode へ m:extends 属性が追加される場合があるため、
+            // getTemplate の後に superPage 解決を行うことで
+            // 初回リクエスト時にも正しくレイアウトが適用される。
+            SuperPageInfo superInfo = resolveSuperPageInfo(page);
+            if (fireEvent && superInfo.page == null) {
+                executeBeforeRenderOnAllParentSpecifications(page, pageStack);
+            }
+
             suffix = superInfo.suffix;
             extension = superInfo.extension;
             page = superInfo.page;

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/ExtendsFromTemplateIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/ExtendsFromTemplateIntegrationTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.layout.extends_from_template;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+
+/**
+ * HTML テンプレートのノードに書かれた {@code m:extends} 属性を元に
+ * レイアウト共有を行うケースの統合テスト。
+ *
+ * <p>{@link HtmlExtendsTemplateBuilder} が {@code setupExtends} を
+ * オーバーライドして HTML エレメントの {@code m:extends} 属性を読み取り、
+ * ページの mayaaNode へ転写することでレイアウトを適用する。</p>
+ *
+ * <p>問題の背景：{@code RenderUtil.renderPage} 内で
+ * {@code resolveSuperPageInfo(page)} が {@code getTemplate(...)} より先に
+ * 呼ばれていたため、テンプレートビルド中に {@code setupExtends} が
+ * mayaaNode へ設定した {@code m:extends} が初回リクエスト時に参照されなかった。</p>
+ */
+public class ExtendsFromTemplateIntegrationTest extends EngineTestBase {
+
+    private static final String BASE = "/it-case/extends-from-template/";
+
+    /**
+     * HTML テンプレートのルートノードに {@code m:extends} を書いた場合に
+     * 初回リクエストでレイアウトが適用されることを確認する。
+     *
+     * <p>{@code generateMayaaNode=true} のため対応する .mayaa ファイルが
+     * 存在しなくても mayaaNode を自動生成し、HTML から読み取った {@code m:extends}
+     * が初回リクエスト時に正しく参照されることを検証する。</p>
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    void htmlノードのm_extends属性で初回リクエストでレイアウトが適用される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "html-extends-first-request";
+        String casePath = BASE + caseName + "/";
+        String layoutHtmlPath = casePath + "layout.html";
+        String targetHtmlPath = casePath + "target.html";
+        String expectedPath = casePath + "expected.html";
+
+        String layoutHtml = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+        // ターゲット HTML に xmlns:m を宣言して m:extends でレイアウトを指定する
+        String targetHtml = "<html xmlns:m=\"http://mayaa.seasar.org\" m:extends=\"" + layoutHtmlPath + "\">"
+                + "<head></head><body><p id=\"content\">TARGET-CONTENT</p></body></html>";
+        // レイアウトに m:insert がないのでターゲットコンテンツは出力されない
+        String expected = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+    }
+
+    /**
+     * HTML テンプレートのルートノードに {@code m:extends} を書いた場合に
+     * 2 回目のリクエストでもレイアウトが適用されることを確認する。
+     * （初回後にテンプレートキャッシュが効いている状態）
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    void htmlノードのm_extends属性で2回目のリクエストでもレイアウトが適用される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "html-extends-second-request";
+        String casePath = BASE + caseName + "/";
+        String layoutHtmlPath = casePath + "layout.html";
+        String targetHtmlPath = casePath + "target.html";
+        String expectedPath = casePath + "expected.html";
+
+        String layoutHtml = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+        String targetHtml = "<html xmlns:m=\"http://mayaa.seasar.org\" m:extends=\"" + layoutHtmlPath + "\">"
+                + "<head></head><body><p id=\"content\">TARGET-CONTENT</p></body></html>";
+        String expected = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        // 1 回目
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+        // 2 回目（テンプレートがキャッシュされている状態）
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+    }
+
+    /**
+     * HTML の {@code m:extends} と .mayaa ファイルの {@code m:doRender} を組み合わせて、
+     * コンテンツがレイアウトのスロットへ正しく挿入されることを確認する。
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    void htmlのm_extendsとmayaaのm_doRenderでコンテンツをレイアウトへ挿入できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+        enableDump();
+
+        String caseName = "html-extends-with-dorender";
+        String casePath = BASE + caseName + "/";
+        String layoutHtmlPath = casePath + "layout.html";
+        String layoutMayaaPath = casePath + "layout.mayaa";
+        String targetHtmlPath = casePath + "target.html";
+        String targetMayaaPath = casePath + "target.mayaa";
+        String expectedPath = casePath + "expected.html";
+
+        String layoutHtml = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">layout-default</div>
+                </body></html>
+                """;
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="slot" name="contentBody" replace="false" />
+                </m:mayaa>
+                """;
+        // ターゲット HTML ルートノードで m:extends によりレイアウトを指定
+        String targetHtml = "<html xmlns:m=\"http://mayaa.seasar.org\" m:extends=\"" + layoutHtmlPath + "\">"
+                + "<head></head><body><div id=\"content\">PAGE-CONTENT</div></body></html>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:doRender id="content" name="contentBody" />
+                </m:mayaa>
+                """;
+        String expected = """
+                <!DOCTYPE html>
+                <html><head></head><body>
+                <div id="slot">PAGE-CONTENT</div>
+                </body></html>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath, layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+    }
+
+    /**
+     * レイアウトページ自身へのリクエストには {@code m:extends} が適用されず
+     * そのままレンダリングされることを確認する。（自己参照防止）
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    void レイアウトページ自身へのリクエストにはレイアウトが適用されない(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "html-extends-layout-self";
+        String casePath = BASE + caseName + "/";
+        String layoutHtmlPath = casePath + "layout.html";
+        String targetHtmlPath = casePath + "target.html";
+        String expectedPath = casePath + "expected.html";
+
+        String layoutHtml = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+        String targetHtml = "<html xmlns:m=\"http://mayaa.seasar.org\" m:extends=\"" + layoutHtmlPath + "\">"
+                + "<head></head><body><p id=\"content\">TARGET-CONTENT</p></body></html>";
+        // レイアウトページ自身は m:extends が付かないのでそのままレンダリングされる
+        String expected = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        execAndVerify(layoutHtmlPath, expectedPath, new LinkedHashMap<>());
+    }
+
+    void setUseNewParser(boolean useNewParser) {
+        getServiceProvider().getTemplateBuilder().setParameter(
+                TemplateBuilderImpl.USE_NEW_PARSER, Boolean.toString(useNewParser));
+    }
+
+    void setAutoEscapeEnabled(boolean enabled) {
+        getServiceProvider().getScriptEnvironment().setParameter(
+                "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    @AfterEach
+    void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+    }
+}
+

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/HtmlExtendsTemplateBuilder.java
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/HtmlExtendsTemplateBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2004-2026 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.mayaa.functional.layout.extends_from_template;
+
+import static org.seasar.mayaa.impl.CONST_IMPL.QM_EXTENDS;
+
+import java.util.Iterator;
+
+import org.seasar.mayaa.engine.Page;
+import org.seasar.mayaa.engine.Template;
+import org.seasar.mayaa.engine.specification.NodeTreeWalker;
+import org.seasar.mayaa.engine.specification.SpecificationNode;
+import org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder;
+import org.seasar.mayaa.impl.engine.specification.SpecificationUtil;
+import org.seasar.mayaa.impl.util.StringUtil;
+
+/**
+ * HTML テンプレートのノードに書かれた {@code m:extends} 属性を読み取って
+ * ページの mayaaNode に設定するカスタムテンプレートビルダー。
+ *
+ * <p>{@link DefaultLayoutTemplateBuilder#setupExtends} をオーバーライドし、
+ * テンプレートの第1階層ノードを走査して {@code m:extends} 属性が見つかった場合に
+ * mayaaNode へ転写します。HTML に {@code m:extends} がない場合は
+ * スーパークラスの動作（{@code defaultLayoutPageName}）にフォールバックします。</p>
+ *
+ * <p>HTML ファイルに以下のように書くことで対象レイアウトを指定します：</p>
+ * <pre>{@code
+ * <html xmlns:m="http://mayaa.seasar.org" m:extends="/layout.html">
+ * }</pre>
+ */
+public class HtmlExtendsTemplateBuilder extends DefaultLayoutTemplateBuilder {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void setupExtends(Template template) {
+        String extendsValue = findExtendsFromHtml(template);
+        if (!StringUtil.isEmpty(extendsValue)) {
+            Page page = template.getPage();
+            SpecificationNode mayaaNode = getMayaaNode(page);
+
+            if (isGenerateMayaaNode() && mayaaNode == null) {
+                mayaaNode = createMayaaNode(page, template);
+                if (template.getParentNode() != null) {
+                    mayaaNode.setParentNode(template.getParentNode());
+                    template.setParentNode(mayaaNode);
+                }
+                page.addChildNode(mayaaNode);
+            }
+
+            if (mayaaNode != null) {
+                String existing = SpecificationUtil.getAttributeValue(mayaaNode, QM_EXTENDS);
+                if (StringUtil.isEmpty(existing)) {
+                    mayaaNode.addAttribute(QM_EXTENDS, extendsValue);
+                }
+            }
+        } else {
+            // HTML に m:extends がなければデフォルト動作（defaultLayoutPageName を使う）
+            super.setupExtends(template);
+        }
+    }
+
+    /**
+     * テンプレートの第1階層ノードを走査して {@code m:extends}（Mayaa 名前空間）
+     * 属性の値を返します。
+     *
+     * @param template 検索対象のテンプレート
+     * @return 属性値。見つからなければ {@code null}
+     */
+    private String findExtendsFromHtml(Template template) {
+        for (Iterator<NodeTreeWalker> itr = template.iterateChildNode(); itr.hasNext(); ) {
+            SpecificationNode node = (SpecificationNode) itr.next();
+            String value = SpecificationUtil.getAttributeValue(node, QM_EXTENDS);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/WEB-INF/org.seasar.mayaa.provider.ServiceProvider
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE provider
+    PUBLIC "-//The Seasar Foundation//DTD Mayaa Provider 1.0//EN"
+    "http://mayaa.seasar.org/dtd/mayaa-provider_1_0.dtd">
+<provider class="org.seasar.mayaa.impl.provider.ServiceProviderImpl">
+    <engine>
+        <errorHandler class="org.seasar.mayaa.impl.engine.error.TemplateErrorHandler">
+            <parameter name="folder" value="/"/>
+            <parameter name="extension" value="html"/>
+        </errorHandler>
+        <parameter name="checkTimestamp" value="true"/>
+        <parameter name="suffixSeparator" value="$"/>
+        <parameter name="requestedSuffixEnabled" value="false" />
+        <parameter name="welcomeFileName" value="index.html"/>
+        <parameter name="requestCharacterEncoding" value="UTF-8"/>
+        <parameter name="pageSerialize" value="false"/>
+        <parameter name="surviveLimit" value="5"/>
+        <parameter name="forwardLimit" value="10"/>
+        <parameter name="noCacheValue" value="no-cache"/>
+        <parameter name="dumpEnabled" value="false" />
+        <parameter name="convertCharset" value="true" />
+    </engine>
+
+    <scriptEnvironment>
+        <scope class="org.seasar.mayaa.impl.cycle.scope.ParamScope"/>
+        <scope class="org.seasar.mayaa.impl.cycle.scope.HeaderScope"/>
+        <scope class="org.seasar.mayaa.impl.cycle.scope.BindingScope"/>
+        <scope class="org.seasar.mayaa.impl.cycle.script.rhino.WalkStandardScope"/>
+        <parameter name="wrapFactory" value="org.seasar.mayaa.impl.cycle.script.rhino.WrapFactoryImpl"/>
+    </scriptEnvironment>
+
+    <specificationBuilder>
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="outputMayaaWhitespace" value="false"/>
+    </specificationBuilder>
+
+    <libraryManager>
+        <converter name="ProcessorProperty" class="org.seasar.mayaa.impl.builder.library.converter.ProcessorPropertyConverter"/>
+        <converter name="PrefixAwareName" class="org.seasar.mayaa.impl.builder.library.converter.PrefixAwareNameConverter"/>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.FolderSourceScanner">
+            <parameter name="folder" value="/WEB-INF"/>
+            <parameter name="recursive" value="true"/>
+            <parameter name="extension" value=".tld"/>
+            <parameter name="extension" value=".mld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.MetaInfSourceScanner">
+            <parameter name="folder" value="/WEB-INF/lib"/>
+            <parameter name="extension" value=".jar"/>
+            <parameter name="ignore" value="commons-beanutils-"/>
+            <parameter name="ignore" value="commons-collections-"/>
+            <parameter name="ignore" value="commons-logging-"/>
+            <parameter name="ignore" value="nekohtml-"/>
+            <parameter name="ignore" value="jaxen-"/>
+            <parameter name="ignore" value="xml-apis-"/>
+            <parameter name="ignore" value="xercesImpl-"/>
+            <parameter name="ignore" value="rhino-"/>
+            <parameter name="jar.ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="jar.extension" value=".mld"/>
+            <parameter name="jar.extension" value=".tld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.ResourceScanner">
+            <parameter name="root" value="META-INF/"/>
+            <parameter name="ignore" value="META-INF/MANIFEST.MF"/>
+            <parameter name="extension" value=".mld"/>
+            <parameter name="extension" value=".tld"/>
+        </scanner>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.DefaultSourceScanner"/>
+        <scanner class="org.seasar.mayaa.impl.builder.library.scanner.WebXMLTaglibSourceScanner"/>
+        <builder class="org.seasar.mayaa.impl.builder.library.MLDDefinitionBuilder"/>
+        <builder class="org.seasar.mayaa.impl.builder.library.TLDDefinitionBuilder"/>
+    </libraryManager>
+
+    <!--
+        HtmlExtendsTemplateBuilder を使用して、HTML テンプレートのノードに書かれた
+        m:extends 属性を読み取ってレイアウトを適用するカスタムビルダーをテストする。
+        generateMayaaNode=true により、.mayaa ファイルが存在しないページにも
+        自動で mayaaNode を生成してレイアウトを適用できる。
+    -->
+    <templateBuilder class="org.seasar.mayaa.functional.layout.extends_from_template.HtmlExtendsTemplateBuilder">
+        <resolver class="org.seasar.mayaa.impl.builder.injection.MetaValuesSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.ReplaceSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.RenderedSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InsertSetter"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.InjectAttributeInjectionResolver"/>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.EqualsIDInjectionResolver">
+            <parameter name="reportUnresolvedID" value="true"/>
+            <parameter name="reportDuplicatedID" value="true"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/TR/html4}id"/>
+            <parameter name="addAttribute" value="{http://www.w3.org/1999/xhtml}id"/>
+        </resolver>
+        <resolver class="org.seasar.mayaa.impl.builder.injection.XPathMatchesInjectionResolver"/>
+        <parameter name="outputTemplateWhitespace" value="true"/>
+        <parameter name="outputMayaaWhitespace" value="false"/>
+        <parameter name="optimize" value="true"/>
+        <parameter name="defaultCharset" value="UTF-8"/>
+        <parameter name="replaceSSIInclude" value="false"/>
+        <parameter name="balanceTag" value="true"/>
+        <parameter name="generateMayaaNode" value="true"/>
+    </templateBuilder>
+
+    <pathAdjuster class="org.seasar.mayaa.impl.builder.PathAdjusterImpl">
+        <parameter name="enabled" value="true"/>
+        <parameter name="force" value="false"/>
+    </pathAdjuster>
+
+    <templateAttributeReader>
+        <ignoreAttribute
+                qName="{jakarta.tags.core}out" attribute="escapeXml"/>
+        <aliasAttribute
+                qName="{jakarta.tags.fmt}formatN*" attribute="patt*"
+                templateAttribute="formatPattern" />
+        <parameter name="enabled" value="true"/>
+    </templateAttributeReader>
+
+    <parentSpecificationResolver class="org.seasar.mayaa.impl.engine.specification.ParentSpecificationResolverImpl">
+    </parentSpecificationResolver>
+
+</provider>

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/WEB-INF/org.seasar.mayaa.source.PageSourceFactory
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/WEB-INF/org.seasar.mayaa.source.PageSourceFactory
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE factory
+	PUBLIC "-//The Seasar Foundation//DTD Mayaa Factory 1.0//EN"
+    "http://mayaa.seasar.org/dtd/mayaa-factory_1_0.dtd">
+<factory class="org.seasar.mayaa.impl.source.PageSourceFactoryImpl"
+         serviceClass="org.seasar.mayaa.impl.source.PageSourceDescriptor">
+  <parameter name="dynamic" value=""/>
+</factory>


### PR DESCRIPTION
- RenderUtil.calcTemplateStack 内で resolveSuperPageInfo を getTemplate の後に呼ぶよう順序を変更
- setupExtends のオーバーライド等でテンプレートビルド中（afterBuild）にページの mayaaNode へ m:extends 属性が追加されるカスタム拡張パターンで、初回リクエスト時にも正しくレイアウトが適用される
- HtmlExtendsTemplateBuilder: HTML テンプレートノードの m:extends 属性を読み取り mayaaNode に転写するカスタムビルダーをテスト用に実装