### PR TITLE
refactor: Remove Xerces dependency from HTML parser pipeline (except NekoHTML)

### DIFF
--- a/src-impl/org/seasar/mayaa/impl/builder/TemplateNodeHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/TemplateNodeHandler.java
@@ -17,6 +17,7 @@ package org.seasar.mayaa.impl.builder;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -321,7 +322,8 @@ public class TemplateNodeHandler extends SpecificationNodeHandler implements Ent
             InputStream is = getClass().getResourceAsStream(path);
             return new InputSource(is);
         }
-        return null;
+        // 未知のエンティティへのネットワークアクセスをブロック (XXE対策)
+        return new InputSource(new StringReader(""));
     }
 
 

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HTMLErrorReporter.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HTMLErrorReporter.java
@@ -2,13 +2,11 @@ package org.seasar.mayaa.impl.builder.parser;
 
 import java.util.Arrays;
 
-import org.apache.xerces.impl.XMLErrorReporter;
-import org.apache.xerces.xni.XNIException;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-public abstract class HTMLErrorReporter extends XMLErrorReporter{
+public abstract class HTMLErrorReporter {
   ErrorHandler _errorHandler;
   HTMLErrorReporter(ErrorHandler errorHandler) {
     _errorHandler = errorHandler;
@@ -43,7 +41,7 @@ class DefaultHTMLErrorHandler extends HTMLErrorReporter {
           break;
         }
       } catch (SAXException e) {
-        throw new XNIException(e);
+        throw new RuntimeException(e);
       }
     }
   }

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
@@ -16,12 +16,12 @@
 package org.seasar.mayaa.impl.builder.parser;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.BufferUnderflowException;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EmptyStackException;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -308,36 +308,45 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
      * Document Handler
      */
     enum InsertionMode {
-        Initial(TokenHandlerInitial.class),
-        BeforeHtml(TokenHandlerBeforeHtml.class),
-        BeforeHead(TokenHandlerBeforeHead.class),
-        InHead(TokenHandlerInHead.class),
-        InHeadNoScript(TokenHandlerBase.class),
-        AfterHead(TokenHandlerAfterHead.class),
-        InBody(TokenHandlerInBody.class),
-        Text(TokenHandlerBase.class),
-        InTable(TokenHandlerBase.class),
-        InTableText(TokenHandlerBase.class),
-        InCaption(TokenHandlerBase.class),
-        InColumnGroup(TokenHandlerBase.class),
-        InTableBody(TokenHandlerBase.class),
-        InRow(TokenHandlerBase.class),
-        InCell(TokenHandlerBase.class),
-        InSelect(TokenHandlerBase.class),
-        InSelectInTable(TokenHandlerBase.class),
-        InTemplate(TokenHandlerBase.class),
-        AfterBody(TokenHandlerAfterBody.class),
-        InFrameset(TokenHandlerBase.class),
-        AfterFrameset(TokenHandlerBase.class),
-        AfterAfterBody(TokenHandlerBase.class),
-        AfterAfterFrameset(TokenHandlerBase.class);
+        Initial,
+        BeforeHtml,
+        BeforeHead,
+        InHead,
+        InHeadNoScript,
+        AfterHead,
+        InBody,
+        Text,
+        InTable,
+        InTableText,
+        InCaption,
+        InColumnGroup,
+        InTableBody,
+        InRow,
+        InCell,
+        InSelect,
+        InSelectInTable,
+        InTemplate,
+        AfterBody,
+        InFrameset,
+        AfterFrameset,
+        AfterAfterBody,
+        AfterAfterFrameset;
+    }
 
-        Class<? extends TokenHandler> handlerClass;
-        TokenHandler handler;
+    private final EnumMap<InsertionMode, TokenHandler> handlers = new EnumMap<>(InsertionMode.class);
 
-        InsertionMode(Class<? extends TokenHandler> handlerClass) {
-            this.handlerClass = handlerClass;
+    HtmlStandardScanner() {
+        TokenHandlerBase fallback = new TokenHandlerBase();
+        for (InsertionMode m : InsertionMode.values()) {
+            handlers.put(m, fallback);
         }
+        handlers.put(InsertionMode.Initial,     new TokenHandlerInitial());
+        handlers.put(InsertionMode.BeforeHtml,  new TokenHandlerBeforeHtml());
+        handlers.put(InsertionMode.BeforeHead,  new TokenHandlerBeforeHead());
+        handlers.put(InsertionMode.InHead,      new TokenHandlerInHead());
+        handlers.put(InsertionMode.AfterHead,   new TokenHandlerAfterHead());
+        handlers.put(InsertionMode.InBody,      new TokenHandlerInBody());
+        handlers.put(InsertionMode.AfterBody,   new TokenHandlerAfterBody());
     }
 
     public boolean fragmentCase = false;
@@ -360,7 +369,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                 super.emitText(tokenizer, location, text);
             } else {
                 setInsertionMode(InsertionMode.BeforeHtml);
-                insertionMode.handler.emitText(tokenizer, location, text);
+                handlers.get(insertionMode).emitText(tokenizer, location, text);
             }
         }
 
@@ -381,7 +390,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         @Override
         public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
             setInsertionMode(InsertionMode.BeforeHtml);
-            insertionMode.handler.emitTag(tokenizer, location, tagToken, attributes);
+            handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
         }
     }
 
@@ -420,7 +429,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                 }
                 setInsertionMode(InsertionMode.BeforeHead);
 
-                insertionMode.handler.emitTag(tokenizer, location, tagToken, attributes);
+                handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
             }
         }
     }
@@ -464,7 +473,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                     setInsertionMode(InsertionMode.InHead);
                 }
 
-                insertionMode.handler.emitTag(tokenizer, location, tagToken, attributes);
+                handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
             }
         }
     }
@@ -489,7 +498,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                 // headがすでに閉じている状態でbody以外のタグが検出されたとき
                 insertImpliedEndTagIfOpened(QN_HEAD);
                 setInsertionMode(InsertionMode.AfterHead);
-                insertionMode.handler.emitTag(tokenizer, location, tagToken, attributes);
+                handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
             }
         }
     }
@@ -514,7 +523,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                     insertImpliedStartTag(QN_BODY);
                 }
                 setInsertionMode(InsertionMode.InBody);
-                super.emitTag(tokenizer, location, tagToken, attributes);
+                handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
             }
         }
     }
@@ -613,7 +622,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
 
         @Override
         public TokenHandler getNextHandler() {
-            return insertionMode.handler;
+            return handlers.get(insertionMode);
         }
     }
 
@@ -625,14 +634,8 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
             errorReporter.setErrorHandler((ErrorHandler) a);
         }
 
-        for (InsertionMode m: InsertionMode.values()) {
-            try {
-                m.handler = m.handlerClass.getDeclaredConstructor(this.getClass()).newInstance(this);
-                m.handler.setErrorReporter(errorReporter);
-            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-                 | SecurityException | InvocationTargetException | NoSuchMethodException e) {
-                    throw new IllegalStateException(e);
-            }
+        for (TokenHandler h : handlers.values()) {
+            h.setErrorReporter(errorReporter);
         }
 
         tokenizer = new HtmlTokenizer();
@@ -650,7 +653,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
             XMLLocator locator = tokenizer.getLocator();
             documentHandler.startDocument(locator, inputSource.getEncoding(), null, null);
 
-            tokenizer.runTokenizer(insertionMode.handler);
+            tokenizer.runTokenizer(handlers.get(insertionMode));
             // return success
             return true;
         } catch (BufferUnderflowException e) {

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
@@ -132,8 +132,6 @@ public class HtmlStandardScanner {
     // PROPERTEIS
     public static final String PROPERTY_PREFIX = "http://mayaa.seasar.org/parser/property/";
 
-    HTMLErrorReporter errorReporter = new DefaultHTMLErrorHandler(null);
-
     // PROPERTEIS:END
 
     // INTERNAL UTILS
@@ -531,12 +529,6 @@ public class HtmlStandardScanner {
     }
 
     class TokenHandlerBase implements TokenHandler {
-        HTMLErrorReporter errorReporter = new DefaultHTMLErrorHandler(null);
-
-        @Override
-        public void setErrorReporter(HTMLErrorReporter errorReporter) {
-            this.errorReporter = errorReporter;
-        }
 
         @Override
         public void emitXmlDecl(HtmlTokenizer tokenizer, HtmlLocation location, String version, String encoding, String standalone) {
@@ -571,28 +563,14 @@ public class HtmlStandardScanner {
         }
 
         @Override
-        public void reportError(HtmlLocation location, ParseError error, Object[] args) {
-            if (HtmlStandardScanner.LOG.isTraceEnabled()) {
-                LOG.trace("ParseError:" + error + (args == null ? "": (" " + Arrays.toString(args))));
-            }
-            errorReporter.reportError(location, error, args);
-        }
-
-
-        @Override
         public TokenHandler getNextHandler() {
             return handlers.get(insertionMode);
         }
     }
 
     public void reset(org.xml.sax.ErrorHandler errorHandler) {
-        errorReporter.setErrorHandler(errorHandler);
-
-        for (TokenHandler h : handlers.values()) {
-            h.setErrorReporter(errorReporter);
-        }
-
         tokenizer = new HtmlTokenizer();
+        tokenizer.setErrorReporter(new DefaultHTMLErrorHandler(errorHandler));
         tokenizer.setInputSource(inputSource);
         tokenizer.reset();
 
@@ -865,10 +843,6 @@ class HtmlAttributesImpl implements org.xml.sax.Attributes {
 }
 
 interface TokenHandler {
-    void setErrorReporter(HTMLErrorReporter errorReporter);
-
-    void reportError(HtmlLocation location, ParseError error, Object[] args);
-
     void emitText(HtmlTokenizer tokenizer, HtmlLocation location, String text);
 
     void emitXmlDecl(HtmlTokenizer tokenizer, HtmlLocation location, String version, String encoding, String standalone);
@@ -889,6 +863,20 @@ class HtmlTokenizer {
     private static final char CHAR_SUB = 0x1A;
 
     private InputSource inputSource;
+    private HTMLErrorReporter errorReporter = new DefaultHTMLErrorHandler(null);
+
+    public void setErrorReporter(HTMLErrorReporter errorReporter) {
+        this.errorReporter = errorReporter;
+    }
+
+    void reportError(HtmlLocation location, ParseError error, Object[] args) {
+        if (HtmlStandardScanner.LOG_TOKENIZER.isTraceEnabled()) {
+            HtmlStandardScanner.LOG_TOKENIZER.trace("ParseError:" + error
+                + (args == null ? "" : (" " + Arrays.toString(args))));
+        }
+        errorReporter.reportError(location, error, args);
+    }
+
     CharBuffer cbuf;
 
     private int pushedBack = CHAR_SUB;
@@ -1371,7 +1359,7 @@ class HtmlTokenizer {
                         // } else if (c == '&') {
                         //     tokenizeState = TokenizeState.CharacterReference;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0);
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
@@ -1389,7 +1377,7 @@ class HtmlTokenizer {
                         // } else if (c == '&') {
                         //     tokenizeState = TokenizeState.CharacterReference;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
@@ -1405,7 +1393,7 @@ class HtmlTokenizer {
                         if (c == '<') {
                             tokenizeState = TokenizeState.RawTextLessThanSign;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
@@ -1421,7 +1409,7 @@ class HtmlTokenizer {
                         if (c == '<') {
                             tokenizeState = TokenizeState.ScriptDataLessThanSign;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
@@ -1443,16 +1431,16 @@ class HtmlTokenizer {
                             tagToken.nameBuilder.append(c /*Character.toLowerCase(c)*/);
                             tokenizeState = TokenizeState.TagName;
                         } else if (c == '?') {
-                            handler.reportError(location, ParseError.UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME, null);
+                            reportError(location, ParseError.UNEXPECTED_QUESTION_MARK_INSTEAD_OF_TAG_NAME, null);
                             commentBuilder = new StringBuilder();
                             commentBuilder.append(c);
                             mayXmlDeclAsBogusComment = true;
                             tokenizeState = TokenizeState.BogusComment;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
+                            reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
                             appendTextNode('<');
                         } else {
-                            handler.reportError(location, ParseError.INVALID_FIRST_CHARACTER_OF_TAG_NAME, null);
+                            reportError(location, ParseError.INVALID_FIRST_CHARACTER_OF_TAG_NAME, null);
                             tokenizeState = TokenizeState.Data;
                             appendTextNode('<');
                             pushBack();
@@ -1467,15 +1455,15 @@ class HtmlTokenizer {
                             tagToken.nameBuilder.append(c /*Character.toLowerCase(c)*/);
                             tokenizeState = TokenizeState.TagName;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_END_TAG_NAME, null);
+                            reportError(location, ParseError.MISSING_END_TAG_NAME, null);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
+                            reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
                             appendTextNode('<');
                             appendTextNode(0x002F);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.INVALID_FIRST_CHARACTER_OF_TAG_NAME, null);
+                            reportError(location, ParseError.INVALID_FIRST_CHARACTER_OF_TAG_NAME, null);
                             tokenizeState = TokenizeState.BogusComment;
                             pushBack();
                         }
@@ -1495,10 +1483,10 @@ class HtmlTokenizer {
                             emitTextIfAvailable(handler);
                             emitTag(handler, tagToken);
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             tagToken.nameBuilder.append((char) 0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
+                            reportError(location, ParseError.EOF_BEFORE_TAG_NAME, null);
                             appendTextNode('<');
                             appendTextNode(0x002F);
                             emitEof();
@@ -1738,10 +1726,10 @@ class HtmlTokenizer {
                         } else if (c == '<') {
                             tokenizeState = TokenizeState.ScriptDataEscapedLessThanSign;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -1758,11 +1746,11 @@ class HtmlTokenizer {
                         } else if (c == '<') {
                             tokenizeState = TokenizeState.ScriptDataEscapedLessThanSign;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             tokenizeState = TokenizeState.ScriptDataEscaped;
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -1782,11 +1770,11 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.ScriptData;
                             appendTextNode('>');
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             tokenizeState = TokenizeState.ScriptDataEscaped;
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -1901,10 +1889,10 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.ScriptDataDoubleEscapedLessThanSign;
                             appendTextNode('<');
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -1923,11 +1911,11 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.ScriptDataDoubleEscapedLessThanSign;
                             appendTextNode('>');
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             tokenizeState = TokenizeState.ScriptDataDoubleEscaped;
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -1947,11 +1935,11 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.ScriptData;
                             appendTextNode('>');
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             tokenizeState = TokenizeState.ScriptDataDoubleEscaped;
                             appendTextNode(0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
+                            reportError(location, ParseError.EOF_IN_SCRIPT_HTML_COMMENT_LIKE_TEXT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2012,7 +2000,7 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.AfterAttributeName;
                         } else if (c == '=') {
                             // https://html.spec.whatwg.org/multipage/parsing.html#parse-error-unexpected-equals-sign-before-attribute-name
-                            handler.reportError(location, ParseError.UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME, null);
+                            reportError(location, ParseError.UNEXPECTED_EQUALS_SIGN_BEFORE_ATTRIBUTE_NAME, null);
                             attrNameBuilder = new StringBuilder();
                             attrValueBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.AttributeName;
@@ -2035,10 +2023,10 @@ class HtmlTokenizer {
                         } else if (c == '=') {
                             tokenizeState = TokenizeState.BeforeAttributeValue;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             attrNameBuilder.append((char) 0xFFFD);
                         } else if (c == '"' || c == '\'' || c == '<') {
-                            handler.reportError(location, ParseError.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME, null);
+                            reportError(location, ParseError.UNEXPECTED_CHARACTER_IN_ATTRIBUTE_NAME, null);
                             attrNameBuilder.append((char) c);
                         } else {
                             attrNameBuilder.append(c);
@@ -2047,7 +2035,7 @@ class HtmlTokenizer {
                         if (tokenizeState != TokenizeState.AttributeName) {
                             // check duplication
                             if (containSameAttributeName(attrNameBuilder.toString())) {
-                                handler.reportError(location, ParseError.DUPLICATE_ATTRIBUTE, null);
+                                reportError(location, ParseError.DUPLICATE_ATTRIBUTE, null);
                                 attrNameBuilder = new StringBuilder(); // reject this attribute 
                             }
                         }
@@ -2068,7 +2056,7 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.Data;
                             emitTag(handler, tagToken);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitAttribute(null, attrNameBuilder.toString(), attrValueBuilder.toString());
                             emitTextIfAvailable(handler);
                             emitEof();
@@ -2092,7 +2080,7 @@ class HtmlTokenizer {
                         } else if (c == '\'') {
                             tokenizeState = TokenizeState.AttributeValueSingleQuoted;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_ATTRIBUTE_VALUE, null);
+                            reportError(location, ParseError.MISSING_ATTRIBUTE_VALUE, null);
                             emitTextIfAvailable(handler);
                             tokenizeState = TokenizeState.Data;
                             emitTag(handler, tagToken);
@@ -2108,10 +2096,10 @@ class HtmlTokenizer {
                             emitAttribute(null, attrNameBuilder.toString(), attrValueBuilder.toString());
                             tokenizeState = TokenizeState.AfterAttributeValueQuoted;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             attrValueBuilder.append((char) 0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2125,10 +2113,10 @@ class HtmlTokenizer {
                             emitAttribute(null, attrNameBuilder.toString(), attrValueBuilder.toString());
                             tokenizeState = TokenizeState.AfterAttributeValueQuoted;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             attrValueBuilder.append((char) 0xFFFD);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2149,13 +2137,13 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.Data;
                             emitTag(handler, tagToken);
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             attrValueBuilder.append((char) 0xFFFD);
                         } else if (c == '"' || c == '\'' || c == '<' || c == '=' || c == '`') {
-                            handler.reportError(location, ParseError.UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE, null);
+                            reportError(location, ParseError.UNEXPECTED_CHARACTER_IN_UNQUOTED_ATTRIBUTE_VALUE, null);
                             attrValueBuilder.append(c);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2176,11 +2164,11 @@ class HtmlTokenizer {
                             tokenizeState = TokenizeState.Data;
                             emitTag(handler, tagToken);
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_ATTRIBUTES, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_ATTRIBUTES, null);
                             pushBack();
                             tokenizeState = TokenizeState.BeforeAttributeName;
                         }
@@ -2194,10 +2182,10 @@ class HtmlTokenizer {
                             emitSelfClosingTag(handler, tagToken);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_TAG, null);
+                            reportError(location, ParseError.EOF_IN_TAG, null);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.UNEXPECTED_SOLIDUS_IN_TAG, null);
+                            reportError(location, ParseError.UNEXPECTED_SOLIDUS_IN_TAG, null);
                             pushBack();
                             tokenizeState = TokenizeState.BeforeAttributeName;
                         }
@@ -2215,11 +2203,11 @@ class HtmlTokenizer {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), mayXmlDeclAsBogusComment);
                             mayXmlDeclAsBogusComment = false;
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             commentBuilder.append((char) 0xFFFD);
                         } else {
                             commentBuilder.append((char) c);
@@ -2234,12 +2222,12 @@ class HtmlTokenizer {
                         } else if (skipStringIgnoreCase("DOCTYPE")) {
                             tokenizeState = TokenizeState.Doctype;
                         } else if (skipString("[CDATA[")) {
-                            handler.reportError(location, ParseError.CDATA_IN_HTML_CONTENT, null);
+                            reportError(location, ParseError.CDATA_IN_HTML_CONTENT, null);
                             commentBuilder = new StringBuilder();
                             commentBuilder.append("[CDATA[");
                             tokenizeState = TokenizeState.BogusComment;
                         } else {
-                            handler.reportError(location, ParseError.INCORRECTLY_OPENED_COMMENT, null);
+                            reportError(location, ParseError.INCORRECTLY_OPENED_COMMENT, null);
                             tokenizeState = TokenizeState.BogusComment;
                         }
                         break;
@@ -2249,7 +2237,7 @@ class HtmlTokenizer {
                         if (c == '-') {
                             tokenizeState = TokenizeState.CommentStartDash;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_CLOSING_OF_EMPTY_COMMENT, null);
+                            reportError(location, ParseError.ABRUPT_CLOSING_OF_EMPTY_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), mayXmlDeclAsBogusComment);
                             mayXmlDeclAsBogusComment = false;
@@ -2265,14 +2253,14 @@ class HtmlTokenizer {
                         if (c == '-') {
                             tokenizeState = TokenizeState.CommentEnd;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_CLOSING_OF_EMPTY_COMMENT, null);
+                            reportError(location, ParseError.ABRUPT_CLOSING_OF_EMPTY_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2293,12 +2281,12 @@ class HtmlTokenizer {
                         } else if (c == '-') {
                             tokenizeState = TokenizeState.CommentEndDash;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             commentBuilder.append((char) 0xFFFD);
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2349,7 +2337,7 @@ class HtmlTokenizer {
                             pushBack();
                             tokenizeState = TokenizeState.CommentEnd;
                         } else {
-                            handler.reportError(location, ParseError.NESTED_COMMENT, null);
+                            reportError(location, ParseError.NESTED_COMMENT, null);
                             pushBack();
                             tokenizeState = TokenizeState.CommentEnd;
                         }
@@ -2361,7 +2349,7 @@ class HtmlTokenizer {
                         if (c == '-') {
                             tokenizeState = TokenizeState.CommentEnd;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
                             emitTextIfAvailable(handler);
@@ -2387,7 +2375,7 @@ class HtmlTokenizer {
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2409,12 +2397,12 @@ class HtmlTokenizer {
                         } else if (c == '>') {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
-                            handler.reportError(location, ParseError.INCORRECTLY_CLOSED_COMMENT, null);
+                            reportError(location, ParseError.INCORRECTLY_CLOSED_COMMENT, null);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
                             emitComment(handler, commentBuilder.toString(), false);
-                            handler.reportError(location, ParseError.EOF_IN_COMMENT, null);
+                            reportError(location, ParseError.EOF_IN_COMMENT, null);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
@@ -2435,14 +2423,14 @@ class HtmlTokenizer {
                             pushBack();
                             tokenizeState = TokenizeState.BeforeDoctypeName;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitTextIfAvailable(handler);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_BEFORE_DOCTYPE_NAME, null);
                             pushBack();
                             tokenizeState = TokenizeState.BeforeDoctypeName;
                         }
@@ -2458,17 +2446,17 @@ class HtmlTokenizer {
                             doctype.nameBuilder.append(c /*Character.toLowerCase(c)*/);
                             tokenizeState = TokenizeState.DoctypeName;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.nameBuilder.append((char) 0xFFFD);
                             tokenizeState = TokenizeState.DoctypeName;
                         } else if (c == '>' ) {
-                            handler.reportError(location, ParseError.MISSING_DOCTYPE_NAME, null);
+                            reportError(location, ParseError.MISSING_DOCTYPE_NAME, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2489,14 +2477,14 @@ class HtmlTokenizer {
                         } else if (Character.isAlphabetic(c)) {
                             doctype.nameBuilder.append(c /*Character.toLowerCase(c)*/);
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.nameBuilder.append((char) 0xFFFD);
                         } else if (c == '>' ) {
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
@@ -2515,7 +2503,7 @@ class HtmlTokenizer {
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2526,7 +2514,7 @@ class HtmlTokenizer {
                             } else if ((c == 's' || c == 'S') && skipStringIgnoreCase("YSTEM")) {
                                 tokenizeState = TokenizeState.AfterDoctypeSystemKeyword;
                             } else {
-                                handler.reportError(location, ParseError.INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME, null);
+                                reportError(location, ParseError.INVALID_CHARACTER_SEQUENCE_AFTER_DOCTYPE_NAME, null);
                                 pushBack();
                                 doctype.forceQuirkFlag = true;
                                 tokenizeState = TokenizeState.BogusDoctype;
@@ -2540,27 +2528,27 @@ class HtmlTokenizer {
                         if (c == '\t'/*TAB*/ || c == '\n'/*LINEFEED*/ || c == 0x0C/*FORMFEED*/ || c == ' ') {
                             tokenizeState = TokenizeState.BeforeDoctypePublicIdentifier;
                         } else if (c == '"') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD, null);
                             doctype.publicIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypePublicIdentifierDoubleQuoted;
                         } else if (c == '\'') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_PUBLIC_KEYWORD, null);
                             doctype.publicIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypePublicIdentifierSingleQuoted;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2579,19 +2567,19 @@ class HtmlTokenizer {
                             doctype.publicIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypePublicIdentifierSingleQuoted;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2604,16 +2592,16 @@ class HtmlTokenizer {
                         if (c == '"') {
                             tokenizeState = TokenizeState.AfterDoctypePublicIdentifier;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.publicIdBuilder.append((char) 0xFFFD);
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2629,16 +2617,16 @@ class HtmlTokenizer {
                         if (c == '\'') {
                             tokenizeState = TokenizeState.AfterDoctypePublicIdentifier;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.publicIdBuilder.append((char) 0xFFFD);
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER, null);
+                            reportError(location, ParseError.ABRUPT_DOCTYPE_PUBLIC_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2658,21 +2646,21 @@ class HtmlTokenizer {
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == '"') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS, null);
                             doctype.systemIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierDoubleQuoted;
                         } else if (c == '\'') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS, null);
                             doctype.systemIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierSingleQuoted;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2695,13 +2683,13 @@ class HtmlTokenizer {
                             doctype.systemIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierSingleQuoted;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2714,27 +2702,27 @@ class HtmlTokenizer {
                         if (c == '\t'/*TAB*/ || c == '\n'/*LINEFEED*/ || c == 0x0C/*FORMFEED*/ || c == ' ') {
                             tokenizeState = TokenizeState.BeforeDoctypePublicIdentifier;
                         } else if (c == '"') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD, null);
                             doctype.publicIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierDoubleQuoted;
                         } else if (c == '\'') {
-                            handler.reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD, null);
+                            reportError(location, ParseError.MISSING_WHITESPACE_AFTER_DOCTYPE_SYSTEM_KEYWORD, null);
                             doctype.publicIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierSingleQuoted;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2753,19 +2741,19 @@ class HtmlTokenizer {
                             doctype.systemIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.DoctypeSystemIdentifierSingleQuoted;
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.MISSING_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.MISSING_QUOTE_BEFORE_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2779,16 +2767,16 @@ class HtmlTokenizer {
                         if (c == '"') {
                             tokenizeState = TokenizeState.AfterDoctypeSystemIdentifier;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.systemIdBuilder.append((char) 0xFFFD);
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2805,16 +2793,16 @@ class HtmlTokenizer {
                             doctype.systemIdBuilder = new StringBuilder();
                             tokenizeState = TokenizeState.AfterDoctypeSystemIdentifier;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             doctype.systemIdBuilder.append((char) 0xFFFD);
                         } else if (c == '>') {
-                            handler.reportError(location, ParseError.ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
@@ -2834,13 +2822,13 @@ class HtmlTokenizer {
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_DOCTYPE, null);
+                            reportError(location, ParseError.EOF_IN_DOCTYPE, null);
                             doctype.forceQuirkFlag = true;
                             emitTextIfAvailable(handler);
                             emitDoctype(handler, doctype);
                             emitEof();
                         } else {
-                            handler.reportError(location, ParseError.UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER, null);
+                            reportError(location, ParseError.UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER, null);
                             doctype.forceQuirkFlag = false; // (This does not set the current DOCTYPE token's force-quirks flag to on.) 
                             pushBack();
                             tokenizeState = TokenizeState.BogusDoctype;
@@ -2855,7 +2843,7 @@ class HtmlTokenizer {
                             emitDoctype(handler, doctype);
                             tokenizeState = TokenizeState.Data;
                         } else if (c == 0) {
-                            handler.reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
+                            reportError(location, ParseError.UNEXPECTED_NULL_CHARACTER, null);
                             // ignore this character
                         } else if (c == CHAR_SUB) {
                             emitTextIfAvailable(handler);
@@ -2872,7 +2860,7 @@ class HtmlTokenizer {
                         if (c == ']') {
                             tokenizeState = TokenizeState.CDataSectionBracket;
                         } else if (c == CHAR_SUB) {
-                            handler.reportError(location, ParseError.EOF_IN_CDATA, null);
+                            reportError(location, ParseError.EOF_IN_CDATA, null);
                             emitEof();
                         } else {
                             appendTextNode(c); 

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlStandardScanner.java
@@ -24,30 +24,14 @@ import java.util.EmptyStackException;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Stack;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.xerces.impl.Constants;
-import org.apache.xerces.util.ErrorHandlerWrapper;
-import org.apache.xerces.xni.Augmentations;
-import org.apache.xerces.xni.QName;
-import org.apache.xerces.xni.XMLAttributes;
-import org.apache.xerces.xni.XMLDocumentHandler;
-import org.apache.xerces.xni.XMLLocator;
-import org.apache.xerces.xni.XMLString;
-import org.apache.xerces.xni.XNIException;
-import org.apache.xerces.xni.parser.XMLComponent;
-import org.apache.xerces.xni.parser.XMLComponentManager;
-import org.apache.xerces.xni.parser.XMLConfigurationException;
-import org.apache.xerces.xni.parser.XMLDocumentScanner;
-import org.apache.xerces.xni.parser.XMLErrorHandler;
-import org.apache.xerces.xni.parser.XMLInputSource;
 import org.seasar.mayaa.impl.builder.parser.HtmlTokenizer.TagToken;
+import org.xml.sax.InputSource;
 import org.seasar.mayaa.impl.knowledge.HTMLKnowledge;
-import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
 
 /**
@@ -56,7 +40,7 @@ import org.xml.sax.Locator;
  * フォーマル公開識別子については妥当性の検証を行わない。
  * HTML文字参照以外は解決しない
  */
-public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
+public class HtmlStandardScanner {
     static final Log LOG = LogFactory.getLog(HtmlStandardScanner.class);
     static final Log LOG_TOKENHANDLER = LogFactory.getLog(HtmlStandardScanner.class.getName() + ".TokenHandler");
     static final Log LOG_TOKENIZER = LogFactory.getLog(HtmlStandardScanner.class.getName() + ".Tokenizer");
@@ -73,40 +57,33 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
 
     static final String NS_URI_XMLNS = "http://www.w3.org/2000/xmlns/";
 
-    static final Attributes EMPTY_ATTRIBUTES = new Attributes();
+    static final HtmlAttributesImpl EMPTY_ATTRIBUTES = new HtmlAttributesImpl();
 
     static final Pattern REGEX_WHITESPACE_ONLY = Pattern.compile("\\s+");
 
-    static final QName QN_HTML = new QName(null, "html", "html", NS_URI_HTML);
-    static final QName QN_HEAD = new QName(null, "head", "head", NS_URI_HTML);
-    static final QName QN_BODY = new QName(null, "body", "body", NS_URI_HTML);
-    static final QName QN_TEMPLATE = new QName(null, "template", "template", NS_URI_HTML);
-
-    static {
-        QN_HEAD.hashCode();
-    }
+    static final ElemName QN_HTML = new ElemName(null, "html", "html", NS_URI_HTML);
+    static final ElemName QN_HEAD = new ElemName(null, "head", "head", NS_URI_HTML);
+    static final ElemName QN_BODY = new ElemName(null, "body", "body", NS_URI_HTML);
+    static final ElemName QN_TEMPLATE = new ElemName(null, "template", "template", NS_URI_HTML);
     /**  */
-    XMLDocumentHandler documentHandler = null;
+    HtmlDocumentHandler documentHandler = null;
 
     HtmlTokenizer tokenizer;
 
     //ByteBuffer buffer = ByteBuffer.allocate(8 * 1024);
     // CharBuffer buffer = CharBuffer.allocate(8 * 1024);
-    XMLInputSource inputSource;
+    InputSource inputSource;
 
-    @Override
-    public void setInputSource(XMLInputSource inputSource) throws IOException {
+    public void setInputSource(InputSource inputSource) throws IOException {
         tokenizer.setInputSource(inputSource);
         this.inputSource = inputSource;
     }
 
-    @Override
-    public void setDocumentHandler(XMLDocumentHandler handler) {
+    public void setDocumentHandler(HtmlDocumentHandler handler) {
         this.documentHandler = handler;
     }
 
-    @Override
-    public XMLDocumentHandler getDocumentHandler() {
+    public HtmlDocumentHandler getDocumentHandler() {
         return documentHandler;
     }
 
@@ -120,7 +97,6 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
     boolean featureDeleteUnexpectedElement = false;
     boolean featureDocumentFragment = true;
     
-    @Override
     public String[] getRecognizedFeatures() {
         return new String[] {
             FEATURE_DELETE_UNEXPECTED_ELEMENT,
@@ -129,7 +105,6 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         };
     }
 
-    @Override
     public Boolean getFeatureDefault(String featureId) {
         switch (featureId) {
             case FEATURE_DELETE_UNEXPECTED_ELEMENT: return Boolean.FALSE;
@@ -139,8 +114,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         }
     }
 
-    @Override
-    public void setFeature(String featureId, boolean state) throws XMLConfigurationException {
+    public void setFeature(String featureId, boolean state) {
         switch (featureId) {
             case FEATURE_DELETE_UNEXPECTED_ELEMENT:
                 featureDeleteUnexpectedElement = state;
@@ -160,20 +134,6 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
 
     HTMLErrorReporter errorReporter = new DefaultHTMLErrorHandler(null);
 
-    @Override
-    public String[] getRecognizedProperties() {
-        return new String[] {
-        };
-    }
-
-    @Override
-    public Object getPropertyDefault(String propertyId) {
-        return null;
-    }
-
-    @Override
-    public void setProperty(String propertyId, Object value) throws XMLConfigurationException {
-    }
     // PROPERTEIS:END
 
     // INTERNAL UTILS
@@ -186,86 +146,86 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         return false;
     }
 
-    QName createHtmlQName(String tagName) {
-        return new QName(null, tagName, tagName, NS_URI_HTML);
+    ElemName createHtmlElemName(String tagName) {
+        return new ElemName(null, tagName, tagName, NS_URI_HTML);
     }
 
-    void insertStartTag(TagToken tagToken, XMLAttributes attributes) {
-        QName qName = createHtmlQName(tagToken.nameBuilder.toString());
-        insertStartTag(qName, attributes);
+    void insertStartTag(TagToken tagToken, HtmlAttributesImpl attributes) {
+        ElemName elemName = createHtmlElemName(tagToken.nameBuilder.toString());
+        insertStartTag(elemName, attributes);
     }
 
-    void insertStartTag(QName qName, XMLAttributes attributes) {
-        if (HTMLKnowledge.isVoidElementLocalPart(qName.localpart)) {
+    void insertStartTag(ElemName elemName, HtmlAttributesImpl attributes) {
+        if (HTMLKnowledge.isVoidElementLocalPart(elemName.localName())) {
             if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                LOG_TOKENHANDLER.trace(String.format("%s: Insert void tag: <%s>", insertionMode, qName.localpart));
+                LOG_TOKENHANDLER.trace(String.format("%s: Insert void tag: <%s>", insertionMode, elemName.localName()));
             }
-            documentHandler.emptyElement(qName, attributes, null);
+            documentHandler.emptyElement(elemName, attributes);
         } else {
             if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                LOG_TOKENHANDLER.trace(String.format("%s: Insert start tag: <%s>", insertionMode, qName.localpart));
+                LOG_TOKENHANDLER.trace(String.format("%s: Insert start tag: <%s>", insertionMode, elemName.localName()));
             }
-            unclosedElementStack.push(qName);
-            documentHandler.startElement(qName, attributes, null);
+            unclosedElementStack.push(elemName);
+            documentHandler.startElement(elemName, attributes);
         }
     }
 
     void insertEndTag(TagToken tagToken) {
-        QName qName = createHtmlQName(tagToken.nameBuilder.toString());
-        insertEndTag(qName);
+        ElemName elemName = createHtmlElemName(tagToken.nameBuilder.toString());
+        insertEndTag(elemName);
     }
 
-    void insertEndTag(final QName qName) {
+    void insertEndTag(final ElemName elemName) {
         try {
             do {
-                QName qn = unclosedElementStack.peek();
-                if (qName.localpart.equals(qn.localpart)) {
+                ElemName top = unclosedElementStack.peek();
+                if (elemName.localName().equals(top.localName())) {
                     break;
                 }
                 if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                    LOG_TOKENHANDLER.trace(String.format("%s: Insert implied end tag: </%s>", insertionMode, qn.localpart));
+                    LOG_TOKENHANDLER.trace(String.format("%s: Insert implied end tag: </%s>", insertionMode, top.localName()));
                 }
                 unclosedElementStack.pop();
-                documentHandler.endElement(qn, null);
+                documentHandler.endElement(top);
             } while(true);
 
             if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                LOG_TOKENHANDLER.trace(String.format("%s: Insert end tag: </%s>", insertionMode, qName.localpart));
+                LOG_TOKENHANDLER.trace(String.format("%s: Insert end tag: </%s>", insertionMode, elemName.localName()));
             }
             unclosedElementStack.pop();
-            documentHandler.endElement(qName, null);
+            documentHandler.endElement(elemName);
         } catch (EmptyStackException e) {
             // An appropriate end tag token is an end tag token whose tag name matches the tag name of the last start tag 
             // to have been emitted from this tokenizer, if any. If no start tag has been emitted from this tokenizer,
             // then no end tag token is appropriate.
         }
     }
-    void insertImpliedStartTag(QName qName) {
-        if (HTMLKnowledge.isVoidElementLocalPart(qName.localpart)) {
+    void insertImpliedStartTag(ElemName elemName) {
+        if (HTMLKnowledge.isVoidElementLocalPart(elemName.localName())) {
             if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                LOG_TOKENHANDLER.trace(String.format("%s: Insert implied void tag: <%s>", insertionMode, qName.localpart));
+                LOG_TOKENHANDLER.trace(String.format("%s: Insert implied void tag: <%s>", insertionMode, elemName.localName()));
             }
-            documentHandler.emptyElement(qName, EMPTY_ATTRIBUTES, null);
+            documentHandler.emptyElement(elemName, EMPTY_ATTRIBUTES);
         } else {
             if (LOG_TOKENHANDLER.isTraceEnabled()) {
-                LOG_TOKENHANDLER.trace(String.format("%s: Insert implied start tag: <%s>", insertionMode, qName.localpart));
+                LOG_TOKENHANDLER.trace(String.format("%s: Insert implied start tag: <%s>", insertionMode, elemName.localName()));
             }
-            unclosedElementStack.push(qName);
-            documentHandler.startElement(qName, EMPTY_ATTRIBUTES, null);
+            unclosedElementStack.push(elemName);
+            documentHandler.startElement(elemName, EMPTY_ATTRIBUTES);
         }
     }
-    void insertImpliedEndTag(QName qName) {
+    void insertImpliedEndTag(ElemName elemName) {
         if (LOG_TOKENHANDLER.isTraceEnabled()) {
-            LOG_TOKENHANDLER.trace(String.format("%s: Insert implied end tag: </%s>", insertionMode, qName.localpart));
+            LOG_TOKENHANDLER.trace(String.format("%s: Insert implied end tag: </%s>", insertionMode, elemName.localName()));
         }
         unclosedElementStack.pop();
-        documentHandler.endElement(qName, null);
+        documentHandler.endElement(elemName);
     }
 
-    void insertImpliedEndTagIfOpened(final QName qName) {
-        for (QName qn : unclosedElementStack) {
-            if (qn.localpart.equalsIgnoreCase(qName.localpart)) {
-                insertEndTag(qName);
+    void insertImpliedEndTagIfOpened(final ElemName elemName) {
+        for (ElemName en : unclosedElementStack) {
+            if (en.localName().equalsIgnoreCase(elemName.localName())) {
+                insertEndTag(elemName);
                 break;
             }
         }
@@ -303,7 +263,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
      * Initially, the stack of open elements is empty.
      * https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements
      */
-    Stack<QName> unclosedElementStack = new Stack<>();
+    Stack<ElemName> unclosedElementStack = new Stack<>();
     /*
      * Document Handler
      */
@@ -376,7 +336,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         @Override
         public void emitDoctype(HtmlTokenizer tokenizer, HtmlLocation location, String doctypeName, String publicId, String systemId) {
             if (documentHandler != null) {
-                documentHandler.doctypeDecl(doctypeName, publicId, systemId, null);
+                documentHandler.doctypeDecl(doctypeName, publicId, systemId);
             }
             fragmentCase = false;
             setInsertionMode(InsertionMode.BeforeHtml);
@@ -384,11 +344,11 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
 
         @Override
         public void emitXmlDecl(HtmlTokenizer tokenizer, HtmlLocation location, String version, String encoding, String standalone) {
-            documentHandler.xmlDecl(version, encoding, standalone, null);
+            documentHandler.xmlDecl(version, encoding, standalone);
         }
 
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             setInsertionMode(InsertionMode.BeforeHtml);
             handlers.get(insertionMode).emitTag(tokenizer, location, tagToken, attributes);
         }
@@ -416,7 +376,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         }
 
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             final String tagName = tagToken.nameBuilder.toString();
             if (tagToken.isEndTag && !matchOneOfThese(tagName, "head", "body", "html", "br")) {
                 // AND IGNORE THIS TOKEN
@@ -434,6 +394,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         }
     }
 
+
     /**
      * Handle tokens in "before head" insertion mode.
      * https://html.spec.whatwg.org/multipage/parsing.html#the-before-head-insertion-mode
@@ -445,7 +406,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         }
 
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             final String tagName = tagToken.nameBuilder.toString();
             if (tagToken.isEndTag && !matchOneOfThese(tagName, "head", "body", "html", "br")) {
                 // AND IGNORE THIS TOKEN
@@ -458,7 +419,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
                     // present on the top element of the stack of open elements. If it is not, add the attribute
                     // and its corresponding value to that element.
                 }
-                documentHandler.startElement(QN_HEAD, attributes, null);
+                documentHandler.startElement(QN_HEAD, EMPTY_ATTRIBUTES);
                 setInsertionMode(InsertionMode.InHead);
             } else if (isStartTagOf(tagToken, "head")) {
                 insertStartTag(tagToken, attributes);
@@ -484,7 +445,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
      */
     class TokenHandlerInHead extends TokenHandlerBase {
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             if (isStartTagOf(tagToken, "meta", "base", "basefont", "bgsound", "link", "title", "template", "script", "noscript", "noframe", "style")) {
                 insertStartTag(tagToken, attributes);
             } else if (isEndTagOf(tagToken, "template")) {
@@ -509,7 +470,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
      */
     class TokenHandlerAfterHead extends TokenHandlerBase {
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             if (isStartTagOf(tagToken, "head", "meta", "base", "basefont", "bgsound", "link", "title", "template", "script", "noscript", "noframe", "style")) {
                 insertStartTag(tagToken, attributes);
             } else if (isStartTagOf(tagToken, "body")) {
@@ -534,7 +495,7 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
      */
     class TokenHandlerInBody extends TokenHandlerBase {
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {
             if (isStartTagOf(tagToken, "html")) {
                 // Parse error.
                 if (unclosedElementStack.contains(QN_TEMPLATE)) {
@@ -589,25 +550,23 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
     
         @Override
         public void emitComment(HtmlTokenizer tokenizer, HtmlLocation location, String comment) {
-            char[] ch = comment.toCharArray();
-            documentHandler.comment(new XMLString(ch, 0, ch.length), null);
+            documentHandler.comment(comment);
         }
     
         @Override
         public void emitText(HtmlTokenizer tokenizer, HtmlLocation location, String text) {
-            char[] ch = text.toCharArray();
-            documentHandler.characters(new XMLString(ch, 0, ch.length), null);
+            documentHandler.characters(text);
         }
     
         @Override
-        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes) {        
+        public void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes) {        
             final String tagName = tagToken.nameBuilder.toString();
             if (tagToken.isSelfClosingTag) {
-                documentHandler.emptyElement(createHtmlQName(tagName), attributes, null);
+                documentHandler.emptyElement(createHtmlElemName(tagName), attributes);
             } else if (tagToken.isEndTag) {
-                insertEndTag(createHtmlQName(tagName));
+                insertEndTag(createHtmlElemName(tagName));
             } else {
-                insertStartTag(createHtmlQName(tagName), attributes);
+                insertStartTag(createHtmlElemName(tagName), attributes);
             }
         }
 
@@ -626,13 +585,8 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         }
     }
 
-    @Override
-    public void reset(XMLComponentManager componentManager) throws XMLConfigurationException {
-        XMLErrorHandler errorHandler = (XMLErrorHandler) componentManager.getProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_HANDLER_PROPERTY);
-        if (errorHandler instanceof ErrorHandlerWrapper) {
-            Object a = ((ErrorHandlerWrapper) errorHandler).getErrorHandler();
-            errorReporter.setErrorHandler((ErrorHandler) a);
-        }
+    public void reset(org.xml.sax.ErrorHandler errorHandler) {
+        errorReporter.setErrorHandler(errorHandler);
 
         for (TokenHandler h : handlers.values()) {
             h.setErrorReporter(errorReporter);
@@ -647,11 +601,10 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
         fragmentCase = featureDocumentFragment;
     }
 
-    @Override
-    public boolean scanDocument(boolean complete) throws IOException, XNIException {
+    public boolean scanDocument(boolean complete) throws IOException {
         try {
-            XMLLocator locator = tokenizer.getLocator();
-            documentHandler.startDocument(locator, inputSource.getEncoding(), null, null);
+            Locator locator = tokenizer.getLocator();
+            documentHandler.startDocument(locator, inputSource.getEncoding());
 
             tokenizer.runTokenizer(handlers.get(insertionMode));
             // return success
@@ -663,6 +616,26 @@ public class HtmlStandardScanner implements XMLComponent, XMLDocumentScanner {
 
 }
 
+/**
+ * Represents an XML/HTML element name (prefix, localName, rawName, uri).
+ * Replaces Xerces QName within the HTML parser pipeline.
+ */
+record ElemName(String prefix, String localName, String rawName, String uri) {}
+
+/**
+ * Document event receiver for the HTML parser pipeline.
+ * Replaces Xerces XMLDocumentHandler with a SAX-aligned interface.
+ */
+interface HtmlDocumentHandler {
+    void startDocument(org.xml.sax.Locator locator, String encoding) throws java.io.IOException;
+    void xmlDecl(String version, String encoding, String standalone);
+    void doctypeDecl(String name, String publicId, String systemId);
+    void startElement(ElemName elemName, org.xml.sax.Attributes attributes);
+    void endElement(ElemName elemName);
+    void emptyElement(ElemName elemName, org.xml.sax.Attributes attributes);
+    void characters(String text);
+    void comment(String text);
+}
 
 class ScanningInterruptedExeption extends Exception {
     private static final long serialVersionUID = -592372281502837246L;
@@ -676,7 +649,7 @@ class ScanningInterruptedExeption extends Exception {
     }
 }
 
-class HtmlLocation implements Locator, XMLLocator, Cloneable {
+class HtmlLocation implements Locator, Cloneable {
     int line = 1;
     int column = 1;
     int offset = 0;
@@ -709,7 +682,6 @@ class HtmlLocation implements Locator, XMLLocator, Cloneable {
         return column;
     }
 
-    @Override
     public int getCharacterOffset() {
         return offset;
     }
@@ -724,27 +696,22 @@ class HtmlLocation implements Locator, XMLLocator, Cloneable {
         return systemId;
     }
 
-    @Override
     public String getLiteralSystemId() {
         return getSystemId();
     }
 
-    @Override
     public String getBaseSystemId() {
         return getSystemId();
     }
 
-    @Override
     public String getExpandedSystemId() {
         return getSystemId();
     }
 
-    @Override
     public String getEncoding() {
         return null;
     }
 
-    @Override
     public String getXMLVersion() {
         return null;
     }
@@ -776,272 +743,124 @@ class HtmlLocation implements Locator, XMLLocator, Cloneable {
     }
 }
 
-class Attributes implements XMLAttributes {
-    class Attribute {
-        QName attrName;
-        String attrType;
-        String attrValue;
-        Attribute(QName attrName, String attrType, String attrValue) {
-            this.attrName = attrName;
-            this.attrType = attrType;
-            this.attrValue = attrValue;
+/**
+ * Mutable SAX Attributes implementation used internally by the HTML parser.
+ */
+class HtmlAttributesImpl implements org.xml.sax.Attributes {
+    private static final String ATTR_TYPE_CDATA = "CDATA";
+
+    static class Attr {
+        final String prefix;
+        final String localName;
+        final String rawName;
+        final String uri;
+        final String type;
+        String value;
+
+        Attr(String prefix, String localName, String rawName, String uri, String type, String value) {
+            this.prefix = prefix;
+            this.localName = localName;
+            this.rawName = rawName != null ? rawName : localName;
+            this.uri = uri != null ? uri : "";
+            this.type = type != null ? type : ATTR_TYPE_CDATA;
+            this.value = value != null ? value : "";
         }
 
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + getEnclosingInstance().hashCode();
-            result = prime * result + Objects.hash(attrName, attrType, attrValue);
-            return result;
-        }
-        
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (!(obj instanceof Attribute))
-                return false;
-            Attribute other = (Attribute) obj;
-            if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
-                return false;
-            return Objects.equals(attrName, other.attrName) && Objects.equals(attrType, other.attrType)
-                    && Objects.equals(attrValue, other.attrValue);
-        }
-        
-
-        /* (non-Javadoc)
-         * @see java.lang.Object#toString()
-         */
-        
         @Override
         public String toString() {
-            return attrName.rawname + "=\"" + attrValue.toString() + "\"";
+            return rawName + "=\"" + value + "\"";
         }
-
-        private Attributes getEnclosingInstance() {
-            return Attributes.this;
-        }
-        
     }
-    ArrayList<Attribute> attributes = new ArrayList<>();
 
-    
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    
+    private final ArrayList<Attr> attrs = new ArrayList<>();
+
+    void addAttribute(String prefix, String localName, String value) {
+        attrs.add(new Attr(prefix, localName, localName, null, ATTR_TYPE_CDATA, value));
+    }
+
+    void clear() {
+        attrs.clear();
+    }
+
     @Override
     public String toString() {
-        return attributes.toString();
-    }
-
-    @Override
-    public int addAttribute(QName attrName, String attrType, String attrValue) {
-        attributes.add(new Attribute(attrName, attrType, attrValue));
-        return attributes.size() - 1;
-    }
-
-    @Override
-    public void removeAllAttributes() {
-        attributes.clear();
-    }
-
-    @Override
-    public void removeAttributeAt(int attrIndex) {
-        attributes.remove(attrIndex);
+        return attrs.toString();
     }
 
     @Override
     public int getLength() {
-        return attributes.size();
-    }
-
-    @Override
-    public int getIndex(String qName) {
-        int idx = qName.indexOf(':');
-        QName nm = null;
-        if (idx == -1) {
-            nm = new QName(null, qName, qName, null);
-        } else {
-            nm = new QName(qName.substring(0, idx), qName.substring(idx + 1), qName, null);
-        }
-        return attributes.indexOf(new Attribute(nm, null, null));
-    }
-
-    @Override
-    public int getIndex(String uri, String localPart) {
-        QName nm = new QName(null, localPart, localPart, uri);
-        return attributes.indexOf(new Attribute(nm, null, null));
-    }
-
-    @Override
-    public void setName(int attrIndex, QName attrName) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            a.attrName = attrName;
-        }
-    }
-
-    @Override
-    public void getName(int attrIndex, QName attrName) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            attrName.setValues(a.attrName);
-        }
-    }
-
-    @Override
-    public String getPrefix(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrName.prefix;
-        }
-        return null;
+        return attrs.size();
     }
 
     @Override
     public String getURI(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrName.uri;
-        }
-        return null;
+        if (index < 0 || index >= attrs.size()) return null;
+        return attrs.get(index).uri;
     }
 
     @Override
     public String getLocalName(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrName.localpart;
-        }
-        return null;
+        if (index < 0 || index >= attrs.size()) return null;
+        return attrs.get(index).localName;
     }
 
     @Override
     public String getQName(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrName.rawname;
-        }
-        return null;
-    }
-
-    @Override
-    public void setType(int attrIndex, String attrType) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            a.attrType = attrType;
-        }
+        if (index < 0 || index >= attrs.size()) return null;
+        return attrs.get(index).rawName;
     }
 
     @Override
     public String getType(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrType;
-        }
-        return null;
-    }
-
-    @Override
-    public String getType(String qName) {
-        int index = getIndex(qName);
-        if (index != -1) {
-            return attributes.get(index).attrType;
-        }
-        return null;
-    }
-
-    @Override
-    public String getType(String uri, String localName) {
-        int index = getIndex(uri, localName);
-        if (index != -1) {
-            return attributes.get(index).attrType;
-        }
-        return null;
-    }
-
-    @Override
-    public void setValue(int attrIndex, String attrValue) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            a.attrValue = attrValue;
-        }
+        if (index < 0 || index >= attrs.size()) return null;
+        return attrs.get(index).type;
     }
 
     @Override
     public String getValue(int index) {
-        Attribute a = attributes.get(index);
-        if (a != null) {
-            return a.attrValue;
-        }
-        return null;
+        if (index < 0 || index >= attrs.size()) return null;
+        return attrs.get(index).value;
     }
 
     @Override
-    public String getValue(String qName) {
-        int attrIndex = getIndex(qName);
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            return a.attrValue;
+    public int getIndex(String uri, String localName) {
+        for (int i = 0; i < attrs.size(); i++) {
+            Attr a = attrs.get(i);
+            if (a.localName.equals(localName) && a.uri.equals(uri)) return i;
         }
-        return null;
+        return -1;
+    }
+
+    @Override
+    public int getIndex(String qName) {
+        for (int i = 0; i < attrs.size(); i++) {
+            if (attrs.get(i).rawName.equals(qName)) return i;
+        }
+        return -1;
+    }
+
+    @Override
+    public String getType(String uri, String localName) {
+        int i = getIndex(uri, localName);
+        return i >= 0 ? attrs.get(i).type : null;
+    }
+
+    @Override
+    public String getType(String qName) {
+        int i = getIndex(qName);
+        return i >= 0 ? attrs.get(i).type : null;
     }
 
     @Override
     public String getValue(String uri, String localName) {
-        int attrIndex = getIndex(uri, localName);
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            return a.attrValue;
-        }
-        return null;
+        int i = getIndex(uri, localName);
+        return i >= 0 ? attrs.get(i).value : null;
     }
 
     @Override
-    public void setNonNormalizedValue(int attrIndex, String attrValue) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            a.attrValue = attrValue;
-        }
-    }
-
-    @Override
-    public String getNonNormalizedValue(int attrIndex) {
-        Attribute a = attributes.get(attrIndex);
-        if (a != null) {
-            return a.attrValue;
-        }
-        return null;
-    }
-
-    @Override
-    public void setSpecified(int attrIndex, boolean specified) {
-    }
-
-    @Override
-    public boolean isSpecified(int attrIndex) {
-        return false;
-    }
-
-    @Override
-    public Augmentations getAugmentations(int attributeIndex) {
-        return null;
-    }
-
-    @Override
-    public Augmentations getAugmentations(String uri, String localPart) {
-        return null;
-    }
-
-    @Override
-    public Augmentations getAugmentations(String qName) {
-        return null;
-    }
-
-    @Override
-    public void setAugmentations(int attrIndex, Augmentations augs) {
+    public String getValue(String qName) {
+        int i = getIndex(qName);
+        return i >= 0 ? attrs.get(i).value : null;
     }
 }
 
@@ -1058,7 +877,7 @@ interface TokenHandler {
 
     void emitComment(HtmlTokenizer tokenizer, HtmlLocation location, String comment);
 
-    void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, Attributes attributes);
+    void emitTag(HtmlTokenizer tokenizer, HtmlLocation location, TagToken tagToken, HtmlAttributesImpl attributes);
 
     TokenHandler getNextHandler();
 
@@ -1069,13 +888,13 @@ class HtmlTokenizer {
     // Represent EOF
     private static final char CHAR_SUB = 0x1A;
 
-    private XMLInputSource inputSource;
+    private InputSource inputSource;
     CharBuffer cbuf;
 
     private int pushedBack = CHAR_SUB;
     private int lastChar = CHAR_SUB;
     private StringBuilder characterBuilder = new StringBuilder();
-    private Attributes attributes = new Attributes();
+    private HtmlAttributesImpl attributes = new HtmlAttributesImpl();
     private HtmlLocation location = new HtmlLocation();
     private HtmlLocation currentLocation = new HtmlLocation();
 
@@ -1181,13 +1000,13 @@ class HtmlTokenizer {
         this.tokenizeState = state;
     }
 
-    public XMLLocator getLocator() {
+    public Locator getLocator() {
         return location;
     }
 
     public void reset() {
         // RESET PARSING STATES
-        attributes.removeAllAttributes();
+        attributes.clear();
         lastStartTagToken = null;
         location.column = 1;
         location.line = 1;
@@ -1208,7 +1027,7 @@ class HtmlTokenizer {
 
     }
 
-    public void setInputSource(XMLInputSource inputSource) {
+    public void setInputSource(InputSource inputSource) {
         this.inputSource = inputSource;
         reset();
     }
@@ -1330,7 +1149,7 @@ class HtmlTokenizer {
             return;
         }
         // add to current attribute list.
-        attributes.addAttribute(new QName(prefix, name, name, null), name, value);
+        attributes.addAttribute(prefix, name, value);
     }
 
     private void emitEof() throws ScanningInterruptedExeption {
@@ -1483,7 +1302,7 @@ class HtmlTokenizer {
                 default:
                     break;
             }
-            attributes.removeAllAttributes();
+            attributes.clear();
         }
         currentLocation.copyPositionTo(location);
     }
@@ -1501,7 +1320,7 @@ class HtmlTokenizer {
             lastStartTagToken = null;
         }
         handler.emitTag(this, location, tagToken, attributes);
-        attributes.removeAllAttributes();
+        attributes.clear();
         currentLocation.copyPositionTo(location);
     }
 

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
@@ -17,7 +17,6 @@ package org.seasar.mayaa.impl.builder.parser;
 
 import java.io.IOException;
 
-import org.apache.xerces.xni.parser.XMLInputSource;
 import org.seasar.mayaa.impl.CONST_IMPL;
 import org.seasar.mayaa.impl.builder.parser.AdditionalHandler;
 import org.xml.sax.Attributes;
@@ -115,18 +114,9 @@ public class HtmlTemplateParser implements XMLReader, CONST_IMPL {
 
     @Override
     public void parse(InputSource input) throws IOException, SAXException {
-        java.io.Reader charStream = input.getCharacterStream();
-        java.io.InputStream byteStream = input.getByteStream();
-        XMLInputSource xniSource;
-        if (charStream != null) {
-            xniSource = new XMLInputSource(input.getPublicId(), input.getSystemId(), null, charStream, input.getEncoding());
-        } else {
-            xniSource = new XMLInputSource(input.getPublicId(), input.getSystemId(), null, byteStream, input.getEncoding());
-        }
-
         scanner.reset(errorHandler);
         scanner.setDocumentHandler(new SaxBridgeHandler());
-        scanner.setInputSource(xniSource);
+        scanner.setInputSource(input);
         try {
             scanner.scanDocument(true);
         } finally {

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
@@ -17,58 +17,215 @@ package org.seasar.mayaa.impl.builder.parser;
 
 import java.io.IOException;
 
-import org.apache.xerces.parsers.BasicParserConfiguration;
-import org.apache.xerces.xni.XMLDocumentHandler;
 import org.apache.xerces.xni.parser.XMLInputSource;
 import org.seasar.mayaa.impl.CONST_IMPL;
-import org.seasar.mayaa.impl.util.xml.AdditionalSAXParser;
+import org.seasar.mayaa.impl.builder.parser.AdditionalHandler;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.LexicalHandler;
 
 /**
+ * HTMLテンプレートのSAXパーサ実装。
+ * Xerces BasicParserConfiguration / AbstractSAXParser を使わず、
+ * HtmlStandardScanner を直接駆動する軽量 XMLReader 実装。
+ *
  * @author Mitsutaka Watanabe
  */
-public class HtmlTemplateParser extends AdditionalSAXParser implements CONST_IMPL {
-    public static String FEATURE_DELETE_UNEXPECTED_ELEMENT = HtmlStandardScanner.FEATURE_DELETE_UNEXPECTED_ELEMENT;
-    public static String FEATURE_INSERT_IMPLIED_ELEMENT = HtmlStandardScanner.FEATURE_INSERT_IMPLIED_ELEMENT;
+public class HtmlTemplateParser implements XMLReader, CONST_IMPL {
 
-    static class ParserConfiguration extends BasicParserConfiguration {
+    public static final String FEATURE_DELETE_UNEXPECTED_ELEMENT = HtmlStandardScanner.FEATURE_DELETE_UNEXPECTED_ELEMENT;
+    public static final String FEATURE_INSERT_IMPLIED_ELEMENT    = HtmlStandardScanner.FEATURE_INSERT_IMPLIED_ELEMENT;
 
-        HtmlStandardScanner scanner = new HtmlStandardScanner();
+    private static final String LEXICAL_HANDLER_PROPERTY = "http://xml.org/sax/properties/lexical-handler";
 
-        ParserConfiguration() {
-            addComponent(scanner);
+    private final HtmlStandardScanner scanner = new HtmlStandardScanner();
+
+    private ContentHandler contentHandler;
+    private ErrorHandler   errorHandler;
+    private EntityResolver entityResolver;
+    private DTDHandler     dtdHandler;
+    private LexicalHandler lexicalHandler;
+    private AdditionalHandler additionalHandler;
+
+    // ---- XMLReader: features -----------------------------------------------
+
+    @Override
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        Boolean v = scanner.getFeatureDefault(name);
+        return v != null ? v : false;
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) {
+        scanner.setFeature(name, value);
+    }
+
+    // ---- XMLReader: properties ---------------------------------------------
+
+    @Override
+    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (LEXICAL_HANDLER_PROPERTY.equals(name)) {
+            return lexicalHandler;
+        }
+        if (AdditionalHandler.ADDITIONAL_HANDLER.equals(name)) {
+            return additionalHandler;
+        }
+        return null;
+    }
+
+    @Override
+    public void setProperty(String name, Object value)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (LEXICAL_HANDLER_PROPERTY.equals(name)) {
+            lexicalHandler = (LexicalHandler) value;
+        } else if (AdditionalHandler.ADDITIONAL_HANDLER.equals(name)) {
+            additionalHandler = (AdditionalHandler) value;
+        }
+    }
+
+    // ---- XMLReader: handlers -----------------------------------------------
+
+    @Override public ContentHandler getContentHandler() { return contentHandler; }
+    @Override public void setContentHandler(ContentHandler h) { contentHandler = h; }
+
+    @Override public ErrorHandler getErrorHandler() { return errorHandler; }
+    @Override public void setErrorHandler(ErrorHandler h) { errorHandler = h; }
+
+    @Override public EntityResolver getEntityResolver() { return entityResolver; }
+    @Override public void setEntityResolver(EntityResolver r) { entityResolver = r; }
+
+    @Override public DTDHandler getDTDHandler() { return dtdHandler; }
+    @Override public void setDTDHandler(DTDHandler h) { dtdHandler = h; }
+
+    // ---- XMLReader: parse --------------------------------------------------
+
+    @Override
+    public void parse(String systemId) throws IOException, SAXException {
+        parse(new InputSource(systemId));
+    }
+
+    @Override
+    public void parse(InputSource input) throws IOException, SAXException {
+        java.io.Reader charStream = input.getCharacterStream();
+        java.io.InputStream byteStream = input.getByteStream();
+        XMLInputSource xniSource;
+        if (charStream != null) {
+            xniSource = new XMLInputSource(input.getPublicId(), input.getSystemId(), null, charStream, input.getEncoding());
+        } else {
+            xniSource = new XMLInputSource(input.getPublicId(), input.getSystemId(), null, byteStream, input.getEncoding());
+        }
+
+        scanner.reset(errorHandler);
+        scanner.setDocumentHandler(new SaxBridgeHandler());
+        scanner.setInputSource(xniSource);
+        try {
+            scanner.scanDocument(true);
+        } finally {
+            scanner.setInputSource(null);
+        }
+    }
+
+    // ---- HtmlDocumentHandler bridge to SAX ContentHandler -----------------
+
+    private class SaxBridgeHandler implements HtmlDocumentHandler {
+
+        @Override
+        public void startDocument(Locator locator, String encoding) throws IOException {
+            if (contentHandler != null) {
+                contentHandler.setDocumentLocator(locator);
+                try {
+                    contentHandler.startDocument();
+                } catch (SAXException e) {
+                    throw new IOException(e);
+                }
+            }
         }
 
         @Override
-        public void parse(XMLInputSource inputSource) throws IOException {
-            try {
-                scanner.reset(this);
-                XMLDocumentHandler documentHandler = getDocumentHandler();
-                scanner.setDocumentHandler(documentHandler);
-                scanner.setInputSource(inputSource);
-                scanner.scanDocument(true);    
-            } catch (IOException | RuntimeException e) {
-                throw e;
-            } catch (Exception e) {
-                throw e;
-            } finally {
-                scanner.setInputSource(null);
+        public void xmlDecl(String version, String encoding, String standalone) {
+            if (additionalHandler != null) {
+                additionalHandler.xmlDecl(version, encoding, standalone);
             }
         }
-    }
 
-    public HtmlTemplateParser() {
-        super(new ParserConfiguration());
-        // super(isHTML ? new TemplateParserConfiguration(): new StandardParserConfiguration());
-        setFeature("http://xml.org/sax/features/namespaces", false);
-        setFeature("http://xml.org/sax/features/validation", false);
-    }
+        @Override
+        public void doctypeDecl(String name, String publicId, String systemId) {
+            if (lexicalHandler != null) {
+                try {
+                    lexicalHandler.startDTD(name, publicId, systemId);
+                    lexicalHandler.endDTD();
+                } catch (SAXException e) {
+                    // ignore
+                }
+            }
+        }
 
-    public void setFeature(String featureId, boolean state) {
-        try {
-            super.setFeature(featureId, state);
-        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+        @Override
+        public void startElement(ElemName elemName, Attributes attributes) {
+            if (contentHandler != null) {
+                try {
+                    contentHandler.startElement(
+                            elemName.uri() != null ? elemName.uri() : "",
+                            elemName.localName(),
+                            elemName.rawName(),
+                            attributes);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void endElement(ElemName elemName) {
+            if (contentHandler != null) {
+                try {
+                    contentHandler.endElement(
+                            elemName.uri() != null ? elemName.uri() : "",
+                            elemName.localName(),
+                            elemName.rawName());
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void emptyElement(ElemName elemName, Attributes attributes) {
+            startElement(elemName, attributes);
+            endElement(elemName);
+        }
+
+        @Override
+        public void characters(String text) {
+            if (contentHandler != null) {
+                try {
+                    char[] ch = text.toCharArray();
+                    contentHandler.characters(ch, 0, ch.length);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void comment(String text) {
+            if (lexicalHandler != null) {
+                try {
+                    char[] ch = text.toCharArray();
+                    lexicalHandler.comment(ch, 0, ch.length);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 }

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/HtmlTemplateParser.java
@@ -18,7 +18,6 @@ package org.seasar.mayaa.impl.builder.parser;
 import java.io.IOException;
 
 import org.seasar.mayaa.impl.CONST_IMPL;
-import org.seasar.mayaa.impl.builder.parser.AdditionalHandler;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;

--- a/src-impl/org/seasar/mayaa/impl/builder/parser/ParseError.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/parser/ParseError.java
@@ -1,7 +1,5 @@
 package org.seasar.mayaa.impl.builder.parser;
 
-import org.apache.xerces.impl.XMLErrorReporter;
-
 /**
  * HtmlStadaardScannerで発生するエラーの種類を定義する列挙型。
  * 各エラーの詳細はWHATWGのHTML Living Standardを参照。
@@ -57,9 +55,9 @@ enum ParseError {
     ABRUPT_DOCTYPE_SYSTEM_IDENTIFIER,
     UNEXPECTED_CHARACTER_AFTER_DOCTYPE_SYSTEM_IDENTIFIER;
 
-    static final short SEVERITY_ERROR = XMLErrorReporter.SEVERITY_ERROR;
-    static final short SEVERITY_FATAL_ERROR = XMLErrorReporter.SEVERITY_FATAL_ERROR;
-    static final short SEVERITY_WARNING = XMLErrorReporter.SEVERITY_WARNING;
+    static final short SEVERITY_WARNING     = 0;
+    static final short SEVERITY_ERROR       = 1;
+    static final short SEVERITY_FATAL_ERROR = 2;
 
     short severity;
 

--- a/src-impl/org/seasar/mayaa/impl/util/xml/AdditionalSAXParser.java
+++ b/src-impl/org/seasar/mayaa/impl/util/xml/AdditionalSAXParser.java
@@ -15,32 +15,254 @@
  */
 package org.seasar.mayaa.impl.util.xml;
 
-import org.apache.xerces.parsers.AbstractSAXParser;
-import org.apache.xerces.parsers.StandardParserConfiguration;
-import org.apache.xerces.xni.Augmentations;
-import org.apache.xerces.xni.XNIException;
-import org.apache.xerces.xni.parser.XMLParserConfiguration;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
 import org.seasar.mayaa.impl.builder.parser.AdditionalHandler;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
 
 /**
+ * JDK 標準 SAXParserFactory を使った XMLReader 実装。
+ * Xerces の AbstractSAXParser を使わず、xmlDecl イベントは
+ * 入力ストリーム先頭のスキャンで代替する。
+ * xmlDecl は SAX startDocument の直後（_current 初期化済み）に発火する。
+ *
  * @author Koji Suga (Gluegent, Inc.)
  */
-public class AdditionalSAXParser extends AbstractSAXParser {
+public class AdditionalSAXParser implements XMLReader {
+
+    /** バイト数ではなく文字数としての先読みバッファサイズ */
+    private static final int SNIFF_CHARS = 200;
+
+    private final XMLReader delegate;
+
+    private ContentHandler contentHandler;
+    private ErrorHandler   errorHandler;
+    private EntityResolver entityResolver;
+    private DTDHandler     dtdHandler;
+    private AdditionalHandler additionalHandler;
 
     protected AdditionalSAXParser() {
-        this(new StandardParserConfiguration());
-    }
-
-    protected AdditionalSAXParser(XMLParserConfiguration config) {
-        super(config);
-    }
-
-    @Override
-    public void xmlDecl(String version, String encoding, String standalone, Augmentations augs) throws XNIException {
-        super.xmlDecl(version, encoding, standalone, augs);
-        if (fContentHandler instanceof AdditionalHandler) {
-            ((AdditionalHandler) fContentHandler).xmlDecl(version, encoding, standalone);
+        try {
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setNamespaceAware(false);
+            delegate = factory.newSAXParser().getXMLReader();
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new RuntimeException(e);
         }
     }
 
+    // ---- XMLReader: features -----------------------------------------------
+
+    @Override
+    public boolean getFeature(String name)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        return delegate.getFeature(name);
+    }
+
+    @Override
+    public void setFeature(String name, boolean value)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        delegate.setFeature(name, value);
+    }
+
+    // ---- XMLReader: properties ---------------------------------------------
+
+    @Override
+    public Object getProperty(String name)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (AdditionalHandler.ADDITIONAL_HANDLER.equals(name)) {
+            return additionalHandler;
+        }
+        return delegate.getProperty(name);
+    }
+
+    @Override
+    public void setProperty(String name, Object value)
+            throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (AdditionalHandler.ADDITIONAL_HANDLER.equals(name)) {
+            additionalHandler = (AdditionalHandler) value;
+        } else {
+            try {
+                delegate.setProperty(name, value);
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                // ignore Xerces-specific properties
+            }
+        }
+    }
+
+    // ---- XMLReader: handlers -----------------------------------------------
+
+    @Override public ContentHandler getContentHandler() { return contentHandler; }
+    @Override public void setContentHandler(ContentHandler h) { contentHandler = h; }
+
+    @Override public ErrorHandler getErrorHandler() { return errorHandler; }
+    @Override public void setErrorHandler(ErrorHandler h) { errorHandler = h; }
+
+    @Override public EntityResolver getEntityResolver() { return entityResolver; }
+    @Override public void setEntityResolver(EntityResolver r) { entityResolver = r; }
+
+    @Override public DTDHandler getDTDHandler() { return dtdHandler; }
+    @Override public void setDTDHandler(DTDHandler h) { dtdHandler = h; }
+
+    // ---- XMLReader: parse --------------------------------------------------
+
+    @Override
+    public void parse(String systemId) throws IOException, SAXException {
+        parse(new InputSource(systemId));
+    }
+
+    @Override
+    public void parse(InputSource input) throws IOException, SAXException {
+        XmlDeclInfo declInfo = null;
+        if (additionalHandler != null) {
+            declInfo = sniffXmlDecl(input);
+        }
+
+        ContentHandler ch = contentHandler;
+        if (additionalHandler != null && ch != null && declInfo != null) {
+            ch = new XmlDeclFireHandler(ch, additionalHandler, declInfo);
+        }
+        delegate.setContentHandler(ch);
+        delegate.setErrorHandler(errorHandler);
+        delegate.setEntityResolver(entityResolver);
+        delegate.setDTDHandler(dtdHandler);
+        delegate.parse(input);
+    }
+
+    // ---- XML declaration sniffing ------------------------------------------
+
+    /**
+     * 文字ストリームの先頭を mark/reset してXML宣言をスキャンする。
+     * XML宣言が見つかれば {@link XmlDeclInfo} を返す。
+     * ストリームは巻き戻されるため後続のSAXパースに影響しない。
+     */
+    private static XmlDeclInfo sniffXmlDecl(InputSource input) throws IOException {
+        Reader reader = input.getCharacterStream();
+        if (reader == null) {
+            // バイトストリームの場合: Locator2 から取得できないため対象外
+            return null;
+        }
+
+        if (!reader.markSupported()) {
+            reader = new BufferedReader(reader);
+            input.setCharacterStream(reader);
+        }
+
+        reader.mark(SNIFF_CHARS);
+        char[] buf = new char[SNIFF_CHARS];
+        int total = 0;
+        while (total < SNIFF_CHARS) {
+            int n = reader.read(buf, total, SNIFF_CHARS - total);
+            if (n == -1) break;
+            total += n;
+        }
+        reader.reset();
+
+        String head = new String(buf, 0, total);
+
+        // BOM等を除いた <?xml までの位置を探す（先頭3文字以内）
+        int start = head.indexOf("<?xml");
+        if (start < 0 || start > 3) {
+            return null;
+        }
+        int end = head.indexOf("?>", start + 5);
+        if (end < 0) {
+            return null;
+        }
+
+        String attrs = head.substring(start + 5, end);
+        return parseXmlDeclAttrs(attrs);
+    }
+
+    private static XmlDeclInfo parseXmlDeclAttrs(String attrs) {
+        // version, encoding, standalone を順に取り出す
+        Matcher m = Pattern.compile(
+                "version\\s*=\\s*[\"']([^\"']*)[\"']").matcher(attrs);
+        String version = m.find() ? m.group(1) : null;
+
+        m = Pattern.compile(
+                "encoding\\s*=\\s*[\"']([^\"']*)[\"']").matcher(attrs);
+        String encoding = m.find() ? m.group(1) : null;
+
+        m = Pattern.compile(
+                "standalone\\s*=\\s*[\"']([^\"']*)[\"']").matcher(attrs);
+        String standalone = m.find() ? m.group(1) : null;
+
+        if (version == null && encoding == null) {
+            return null;
+        }
+        return new XmlDeclInfo(version, encoding, standalone);
+    }
+
+    // ---- XmlDeclInfo -------------------------------------------------------
+
+    private static final class XmlDeclInfo {
+        final String version;
+        final String encoding;
+        final String standalone;
+
+        XmlDeclInfo(String version, String encoding, String standalone) {
+            this.version    = version;
+            this.encoding   = encoding;
+            this.standalone = standalone;
+        }
+    }
+
+    // ---- ContentHandler wrapper to fire xmlDecl after startDocument --------
+
+    /**
+     * SAX startDocument の直後（_current 初期化後）に xmlDecl を発火する
+     * ContentHandler ラッパー。
+     */
+    private static final class XmlDeclFireHandler implements ContentHandler {
+
+        private final ContentHandler delegate;
+        private final AdditionalHandler additionalHandler;
+        private final XmlDeclInfo declInfo;
+
+        XmlDeclFireHandler(ContentHandler delegate, AdditionalHandler additionalHandler, XmlDeclInfo declInfo) {
+            this.delegate          = delegate;
+            this.additionalHandler = additionalHandler;
+            this.declInfo          = declInfo;
+        }
+
+        @Override
+        public void startDocument() throws SAXException {
+            delegate.startDocument();
+            // xmlDecl は startDocument の直後に発火する（Xerces の動作に準じる）
+            additionalHandler.xmlDecl(
+                    declInfo.version    != null ? declInfo.version    : "1.0",
+                    declInfo.encoding   != null ? declInfo.encoding   : "",
+                    declInfo.standalone);
+        }
+
+        @Override public void setDocumentLocator(Locator locator) { delegate.setDocumentLocator(locator); }
+        @Override public void endDocument() throws SAXException { delegate.endDocument(); }
+        @Override public void startPrefixMapping(String prefix, String uri) throws SAXException { delegate.startPrefixMapping(prefix, uri); }
+        @Override public void endPrefixMapping(String prefix) throws SAXException { delegate.endPrefixMapping(prefix); }
+        @Override public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException { delegate.startElement(uri, localName, qName, atts); }
+        @Override public void endElement(String uri, String localName, String qName) throws SAXException { delegate.endElement(uri, localName, qName); }
+        @Override public void characters(char[] ch, int start, int length) throws SAXException { delegate.characters(ch, start, length); }
+        @Override public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException { delegate.ignorableWhitespace(ch, start, length); }
+        @Override public void processingInstruction(String target, String data) throws SAXException { delegate.processingInstruction(target, data); }
+        @Override public void skippedEntity(String name) throws SAXException { delegate.skippedEntity(name); }
+    }
 }
+

--- a/src-impl/org/seasar/mayaa/impl/util/xml/XMLHandler.java
+++ b/src-impl/org/seasar/mayaa/impl/util/xml/XMLHandler.java
@@ -15,6 +15,7 @@
  */
 package org.seasar.mayaa.impl.util.xml;
 
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -130,7 +131,8 @@ public class XMLHandler extends DefaultHandler {
                     XMLHandler.class, 0, publicId, systemId);
             log.warn(message);
         }
-        return null;
+        // 未知のエンティティへのネットワークアクセスをブロック (XXE対策)
+        return new InputSource(new StringReader(""));
     }
 
     public void startDocument() {


### PR DESCRIPTION
## 概要

HTMLテンプレートパーサーパイプラインから、NekoHTML関連を除くすべての Xerces 依存を排除しました。

## 変更内容

### 主な変更
- **`HtmlTemplateParser`** — `AbstractSAXParser`（Xerces）の代わりに、独自実装の `HtmlStandardScanner` を直接駆動する軽量 `XMLReader` 実装に刷新
- **`HTMLErrorReporter`** — Xerces の `ErrorHandler` 依存を除去し、JDK SAX 標準の `org.xml.sax.ErrorHandler` のみに変更
- **`HtmlStandardScanner`** — Xerces XNI の型（`QName`, `XMLDocumentHandler` など）を独自型（`ElemName`, `HtmlDocumentHandler`）に置き換え
  - `TokenHandler` インターフェースから `errorReporter` 関連を除去（ステートレス化）
  - `errorReporter` を `HtmlTokenizer` に集約し、トークン解析レベルでのエラー報告を内部化
- **`AdditionalSAXParser`** — Xerces `SAXParser` を JDK `SAXParserFactory` ベースに置き換え
- **Security**: XXE脆弱性を修正（EntityResolver実装）

### Xerces依存が残っているクラス（スコープ外）
以下は NekoHTML パーサースタック固有の依存であり、本PRのスコープ外：
- `NekoHtmlParser` — `org.apache.xerces.parsers.AbstractSAXParser`
- `AdditionalHandlerFilter` — `org.apache.xerces.xni.Augmentations`
- `TemplateScanner` — `org.apache.xerces.util.XMLStringBuffer`

## 今後の予定

`NekoHtmlParser` / `TemplateScanner` / `AdditionalHandlerFilter` は旧パーサースタック（NekoHTML + Xerces XNI）を構成しており、`HtmlStandardScanner` ベースの新スタックへ完全移行することで不要になります。移行完了後にこれらのクラスを削除し、Xerces 依存を完全に排除する予定です。

## テスト

- 既存のユニットテスト・インテグレーションテストが通ることを確認してください。