### PR TITLE
fix: treat cached Page as immutable; store default layout in Template (dynamicSuperPagePath)

### DIFF
--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -5,6 +5,7 @@
 ## 目次
 - [1.3.x から 2.0.0 へのアップグレード](#13x-から-200-へのアップグレード)
   - [`DefaultLayoutTemplateBuilder.setupExtends` のシグネチャ変更（非互換）](#defaultlayouttemplatebuildersetupextends-のシグネチャ変更非互換)
+  - [`ParentSpecificationResolver` の親仕様 `beforeRender` / `afterRender` 実行サポート（動作変更）](#parentspecificationresolver-の親仕様-beforerender--afterrender-実行サポート動作変更)
   - [自動エスケープ機能（Issue #110）導入時の互換性注意点](#自動エスケープ機能issue-110導入時の互換性注意点)
 - [1.2.x から 1.3.0 へのアップグレード](#12x-から-130-へのアップグレード)
 - [1.1.x から 1.2 へのアップグレード](#11x-から-12-へのアップグレード)
@@ -74,6 +75,35 @@ protected void setupExtends(Template template) {
 
 `getMayaaNode(Page)` / `createMayaaNode(Page, Specification)` / `addExtends(Page, SpecificationNode)` は
 `@Deprecated` になりました。新実装では使用しないでください。
+
+---
+
+### `ParentSpecificationResolver` の親仕様 `beforeRender` / `afterRender` 実行サポート（動作変更）
+
+**影響範囲:** `ParentSpecificationResolver` を実装・使用しているアプリケーション
+
+#### 1.3.x までの動き
+
+`ParentSpecificationResolver` が親仕様チェーンを返す場合、返された親仕様の `beforeRender` / `afterRender` は**実行されていませんでした**。
+
+#### 2.0.0 での変更
+
+親仕様チェーンの `beforeRender` / `afterRender` が実行されるようになりました（PR #127 #131）。
+
+実行順序は次のとおりです。
+
+```
+beforeRender: parent2（最外側）→ parent1 → page 自身（最内側）
+afterRender:  page 自身（最内側）→ parent1 → parent2（最外側）
+※ default.mayaa の beforeRender/afterRender はページ処理ごとではなく、リクエスト処理ごとに最外の一回のみ
+```
+
+この順序により、Rhino のスコープチェーン（内→外方向で変数を検索）に沿って、
+`beforeRender` 内で宣言した変数を内側の仕様から外側の仕様の変数として参照できます。
+
+> **注意:** 1.3.x では実行されていなかった `beforeRender` / `afterRender` が新たに呼ばれるようになります。`ParentSpecificationResolver` が返す親仕様に `beforeRender` / `afterRender` の処理が定義されている場合、動作が変わります。
+
+---
 
 ### 自動エスケープ機能（Issue #110）導入時の互換性注意点
 

--- a/doc/UPGRADING.md
+++ b/doc/UPGRADING.md
@@ -4,6 +4,8 @@
 
 ## 目次
 - [1.3.x から 2.0.0 へのアップグレード](#13x-から-200-へのアップグレード)
+  - [`DefaultLayoutTemplateBuilder.setupExtends` のシグネチャ変更（非互換）](#defaultlayouttemplatebuildersetupextends-のシグネチャ変更非互換)
+  - [自動エスケープ機能（Issue #110）導入時の互換性注意点](#自動エスケープ機能issue-110導入時の互換性注意点)
 - [1.2.x から 1.3.0 へのアップグレード](#12x-から-130-へのアップグレード)
 - [1.1.x から 1.2 へのアップグレード](#11x-から-12-へのアップグレード)
 - [1.1.32 以前から 1.1.33 以降へのアップグレード](#1132-以前から-1133-以降へのアップグレード)
@@ -11,6 +13,67 @@
 ---
 
 ## 1.3.x から 2.0.0 へのアップグレード
+
+### `DefaultLayoutTemplateBuilder.setupExtends` のシグネチャ変更（非互換）
+
+**影響範囲:** `DefaultLayoutTemplateBuilder` をサブクラス化して `setupExtends` または
+`getMayaaNode` / `createMayaaNode` / `addExtends` をオーバーライドしている実装。
+
+#### 変更の背景
+
+旧実装では `setupExtends` がキャッシュ済みの `Page` インスタンスに
+`m:extends` 属性を持つ mayaaNode を直接追加（ミューテート）していました。
+Caffeine キャッシュ移行後、Page と Template のエビクションタイミングが独立したことで
+「Page だけエビクションされた後に Template が再ビルドされず、mayaaNode が失われる」
+問題が発生したため、設計を変更しました。
+
+#### 新設計の概要
+
+- **キャッシュ済みの `Page` インスタンスはイミュータブルとして扱う。**
+  `setupExtends` は `Page` を直接ミューテートしなくなりました。
+- デフォルトレイアウトのページ名は `TemplateImpl.setDynamicSuperPagePath(String)` を
+  呼び出して **Template 自身** に保持します。
+- 描画時に `RenderUtil` が Page の `.mayaa` 定義（`m:extends`）を優先し、
+  定義がない場合のみ Template の動的設定を参照します。
+
+#### サブクラスへの影響と対応方法
+
+```java
+// 旧: Page をミューテートして mayaaNode に m:extends を追加していた
+@Override
+protected void setupExtends(Template template) {
+    Page page = template.getPage();
+    SpecificationNode mayaaNode = getMayaaNode(page);
+    if (isGenerateMayaaNode() && mayaaNode == null) {
+        mayaaNode = createMayaaNode(page, template);   // Page に子ノード追加
+        page.addChildNode(mayaaNode);
+    }
+    if (mayaaNode != null) {
+        addExtends(page, mayaaNode);                   // Page の属性を書き換え
+    }
+}
+
+// 新: Template に動的パスを設定する。Page は読み取り専用
+@Override
+protected void setupExtends(Template template) {
+    // Page の .mayaa に m:extends が既にある場合は何もしない
+    Page page = template.getPage();
+    SpecificationNode mayaaNode = getMayaaNode(page);
+    if (mayaaNode != null &&
+            !StringUtil.isEmpty(SpecificationUtil.getAttributeValue(mayaaNode, QM_EXTENDS))) {
+        return;  // .mayaa で明示定義済み → 優先される
+    }
+
+    // 動的なレイアウトパスを Template 側に設定
+    String layoutPageName = resolveLayoutPageName(template);  // サブクラスで決定
+    if (StringUtil.hasValue(layoutPageName) && template instanceof TemplateImpl) {
+        ((TemplateImpl) template).setDynamicSuperPagePath(layoutPageName);
+    }
+}
+```
+
+`getMayaaNode(Page)` / `createMayaaNode(Page, Specification)` / `addExtends(Page, SpecificationNode)` は
+`@Deprecated` になりました。新実装では使用しないでください。
 
 ### 自動エスケープ機能（Issue #110）導入時の互換性注意点
 

--- a/src-impl/org/seasar/mayaa/impl/builder/DefaultLayoutTemplateBuilder.java
+++ b/src-impl/org/seasar/mayaa/impl/builder/DefaultLayoutTemplateBuilder.java
@@ -22,6 +22,7 @@ import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
 import org.seasar.mayaa.engine.Template;
 import org.seasar.mayaa.engine.specification.Specification;
 import org.seasar.mayaa.engine.specification.SpecificationNode;
+import org.seasar.mayaa.impl.engine.TemplateImpl;
 import org.seasar.mayaa.impl.engine.specification.SpecificationUtil;
 import org.seasar.mayaa.impl.source.SourceUtil;
 import org.seasar.mayaa.impl.util.ObjectUtil;
@@ -44,8 +45,6 @@ public class DefaultLayoutTemplateBuilder extends TemplateBuilderImpl {
 
     private static final long serialVersionUID = 6472968108941224353L;
 
-    private static final String SYSTEM_ID_SUFFIX = ".mayaa/(auto)";
-
     private String _defaultLayoutPageName;
     private boolean _generateMayaaNode;
 
@@ -57,7 +56,11 @@ public class DefaultLayoutTemplateBuilder extends TemplateBuilderImpl {
 
     /**
      * TemplateBuilderImplの{@link #afterBuild(Specification)}を実行する前に、
-     * 必要ならm:extendsを自動生成します。
+     * 必要ならデフォルトレイアウトの適用設定をします。
+     * <p>
+     * キャッシュ済みの Page インスタンスはイミュータブルとして扱い、直接ミューテートは行いません。
+     * デフォルトレイアウトのページ名は Template 側（{@link TemplateImpl#setDynamicSuperPagePath}）
+     * に保持し、描画時に {@code RenderUtil} が参照します。
      *
      * @param template 処理対象のテンプレート
      */
@@ -70,73 +73,70 @@ public class DefaultLayoutTemplateBuilder extends TemplateBuilderImpl {
         }
 
         Page page = template.getPage();
-        SpecificationNode mayaaNode = getMayaaNode(page);
+        SpecificationNode mayaaNode = SpecificationUtil.getMayaaNode(page);
 
-        if (_generateMayaaNode && mayaaNode == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("default layout - generate mayaa: " + page.getPageName());
-            }
-            mayaaNode = createMayaaNode(page, template);
-            if (template.getParentNode() != null) {
-                mayaaNode.setParentNode(template.getParentNode());
-                template.setParentNode(mayaaNode);
-            }
-            page.addChildNode(mayaaNode);
+        boolean shouldApplyDefault;
+        if (mayaaNode == null) {
+            // .mayaaファイルなし — generateMayaaNode=true の場合のみデフォルトレイアウトを適用
+            shouldApplyDefault = _generateMayaaNode;
+        } else {
+            // .mayaaファイルあり — m:extends が未定義の場合にデフォルトレイアウトを適用
+            shouldApplyDefault = StringUtil.isEmpty(
+                    SpecificationUtil.getAttributeValue(mayaaNode, QM_EXTENDS));
         }
-        if (mayaaNode != null) {
-            addExtends(page, mayaaNode);
+
+        if (shouldApplyDefault && template instanceof TemplateImpl) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("default layout - set extends: " + page.getPageName()
+                        + " m:extends=\"" + _defaultLayoutPageName + "\"");
+            }
+            ((TemplateImpl) template).setDynamicSuperPagePath(_defaultLayoutPageName);
         }
     }
 
     /**
-     * PageのMayaaノードを取得します。
-     * createMayaaNodeで自動生成したノードだった場合、そのノードは削除して
-     * 再度Mayaaノードを取得します。
+     * PageのMayaaノードを取得します（.mayaaファイルに定義されたノードのみ返します）。
      *
      * @param page ビルド対象のページ
-     * @return 自動生成でないMayaaノード。無ければnullを返します。
+     * @return .mayaaファイルに定義されたMayaaノード。無ければnullを返します。
      */
     protected SpecificationNode getMayaaNode(Page page) {
-        SpecificationNode mayaaNode = SpecificationUtil.getMayaaNode(page);
-        if (mayaaNode != null && mayaaNode.getSystemID().endsWith(SYSTEM_ID_SUFFIX)) {
-            page.removeChildNode(mayaaNode);
-            mayaaNode = SpecificationUtil.getMayaaNode(page);
-        }
-        return mayaaNode;
+        return SpecificationUtil.getMayaaNode(page);
     }
 
     /**
      * ページ名に対応したMayaaファイルの代わりを作成します。
      *
-     * @param page Mayaaノードを作成するページ
-     * @param specification sequenceIDを取得するためのspec
-     * @return Mayaaノード
+     * @deprecated Mayaa 2.0 で廃止。Page をミューテートする方式は廃止されました。
+     *             デフォルトレイアウトは {@link TemplateImpl#setDynamicSuperPagePath} で
+     *             Template 側に設定してください。
+     *             詳細は UPGRADING.md の「setupExtends のシグネチャ変更」を参照してください。
+     * @throws UnsupportedOperationException 常にスローされます
      */
+    @Deprecated
     protected SpecificationNode createMayaaNode(
             Page page, Specification specification) {
-        String systemID = page.getPageName() + SYSTEM_ID_SUFFIX;
-
-        return SpecificationUtil.createSpecificationNode(
-                    QM_MAYAA, systemID,
-                    0, false, specification.nextSequenceID());
+        throw new UnsupportedOperationException(
+            "DefaultLayoutTemplateBuilder.createMayaaNode() is removed in Mayaa 2.0. "
+            + "Override setupExtends() and call TemplateImpl.setDynamicSuperPagePath() instead. "
+            + "See UPGRADING.md for migration details.");
     }
 
     /**
      * m:mayaa要素にm:extends属性を追加します。
      *
-     * @param page 処理中のページ
-     * @param mayaaNode 属性を追加するm:mayaa要素
+     * @deprecated Mayaa 2.0 で廃止。Page の属性を直接ミューテートする方式は廃止されました。
+     *             デフォルトレイアウトは {@link TemplateImpl#setDynamicSuperPagePath} で
+     *             Template 側に設定してください。
+     *             詳細は UPGRADING.md の「setupExtends のシグネチャ変更」を参照してください。
+     * @throws UnsupportedOperationException 常にスローされます
      */
+    @Deprecated
     protected void addExtends(Page page, SpecificationNode mayaaNode) {
-        String extendsValue = SpecificationUtil.getAttributeValue(
-                mayaaNode, QM_EXTENDS);
-        if (StringUtil.isEmpty(extendsValue)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("default layout - set extends: " + page.getPageName()
-                        + " m:extends=\"" + _defaultLayoutPageName + "\"");
-            }
-            mayaaNode.addAttribute(QM_EXTENDS, _defaultLayoutPageName);
-        }
+        throw new UnsupportedOperationException(
+            "DefaultLayoutTemplateBuilder.addExtends() is removed in Mayaa 2.0. "
+            + "Override setupExtends() and call TemplateImpl.setDynamicSuperPagePath() instead. "
+            + "See UPGRADING.md for migration details.");
     }
 
     // Parameterizable implements ------------------------------------

--- a/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/EngineImpl.java
@@ -549,6 +549,10 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
                 if (spec.isDeprecated() == false) {
                     if (registerCache) {
                         _specCache.put(spec.getSystemID(), spec);
+                        // デシリアライズ成功時も requestValidSpecCache の null エントリを除去する。
+                        // 除去しないと findValidSpecificationFromCache が null を返し続け、
+                        // createPageInstance が再度呼び出されて別インスタンスが生まれる。
+                        clearRequestValidSpecCache(spec.getSystemID());
                     }
                     return spec;
                 }
@@ -631,7 +635,8 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
                 ((Page) instance).initialize(pageName);
             }
         };
-        return (Page) createSpecificationInstance(pageName + _mayaaExtension, true, generator);
+        Page page = (Page) createSpecificationInstance(pageName + _mayaaExtension, true, generator);
+        return page;
     }
 
     public Template createTemplateInstance(final Page page, final String suffix, final String extension) {
@@ -639,6 +644,16 @@ public class EngineImpl extends NonSerializableParameterAwareImpl implements Eng
         Specification cached = findValidSpecificationFromCache(templateId);
         if (cached != null) {
             return (Template) cached;
+        }
+
+        // Templateビルド中に template.getPage() → engine.getPage() が呼ばれた際、
+        // requestValidSpecCache に page の null エントリが残っていると
+        // findValidSpecificationFromCache が null を返し createPageInstance が再呼び出しされ
+        // 呼び出し元が保持する page とは別のインスタンスが生成されてしまう。
+        // Templateビルド開始前に pageSystemID → page を requestCache へ確実に登録しておく。
+        final Map<String, Specification> requestCache = getRequestValidSpecCache();
+        if (requestCache != null) {
+            requestCache.put(page.getSystemID(), page);
         }
 
         final SpecificationGenerator generator = new SpecificationGenerator() {

--- a/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/PageImpl.java
@@ -82,10 +82,20 @@ public class PageImpl extends SpecificationImpl implements Page {
         if (StringUtil.isEmpty(extendsPath)) {
             return new SuperPageInfo(null, null, null);
         }
+        return resolveExtendsPath(extendsPath);
+    }
+
+    /**
+     * 指定した m:extends パス文字列を解決して SuperPageInfo を返します。
+     * Page 自身の .mayaa 定義によらず、動的に渡されたパスを解決する際に使います。
+     *
+     * @param path m:extends パス（例: "/layout.html"）
+     * @return 解決された SuperPageInfo
+     */
+    SuperPageInfo resolveExtendsPath(String path) {
         Engine engine = ProviderUtil.getEngine();
         String suffixSeparator = engine.getParameter(CONST_IMPL.SUFFIX_SEPARATOR);
-        String[] pagePath = StringUtil.parsePath(extendsPath, suffixSeparator);
-
+        String[] pagePath = StringUtil.parsePath(path, suffixSeparator);
         Page superPage = engine.getPage(
                 StringUtil.adjustRelativePath(_pageName, pagePath[0]));
         return new SuperPageInfo(superPage, pagePath[1], pagePath[2]);

--- a/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
@@ -343,11 +343,10 @@ public class RenderUtil implements CONST_IMPL {
             }
 
             // テンプレートビルド後に resolveSuperPageInfo を呼ぶ。
-            // setupExtends のオーバーライド等でテンプレートビルド中（afterBuild）に
-            // ページの mayaaNode へ m:extends 属性が追加される場合があるため、
-            // getTemplate の後に superPage 解決を行うことで
-            // 初回リクエスト時にも正しくレイアウトが適用される。
-            SuperPageInfo superInfo = resolveSuperPageInfo(page);
+            // setupExtends が Template.setDynamicSuperPagePath で設定したデフォルトレイアウトは
+            // Page（キャッシュ済みイミュータブルインスタンス）には書き込まれないため、
+            // getTemplate の後で template を渡して解決することで正しくレイアウトが適用される。
+            SuperPageInfo superInfo = resolveSuperPageInfo(page, template);
             if (fireEvent && superInfo.page == null) {
                 executeBeforeRenderOnAllParentSpecifications(page, pageStack);
             }
@@ -375,13 +374,31 @@ public class RenderUtil implements CONST_IMPL {
         return ret;
     }
 
-    private static SuperPageInfo resolveSuperPageInfo(Page page) {
+    /**
+     * Page 展開chain を解決します。
+     * <p>
+     * 優先度: Page 自身の .mayaa ファイルの m:extends 属性 &gt; Templateの動的デフォルト設定。
+     * Page 自身に m:extends 定義があればそちらを使用し、
+     * なければ {@link TemplateImpl#getDynamicSuperPagePath()} を参照します。
+     */
+    private static SuperPageInfo resolveSuperPageInfo(Page page, Template template) {
         if (page == null) {
             throw new IllegalArgumentException();
         }
-        if (page instanceof PageImpl) {
-            PageImpl.SuperPageInfo pageImplInfo = ((PageImpl) page).resolveSuperPageInfo();
-            return new SuperPageInfo(pageImplInfo.page, pageImplInfo.suffix, pageImplInfo.extension);
+        if (page instanceof PageImpl pageImpl) {
+            PageImpl.SuperPageInfo pageInfo = pageImpl.resolveSuperPageInfo();
+            if (pageInfo.page != null) {
+                return new SuperPageInfo(pageInfo.page, pageInfo.suffix, pageInfo.extension);
+            }
+            // Pageに m:extends なし — Templateの動的設定をフォールバックとして使用
+            if (template instanceof TemplateImpl templateImpl) {
+                String dynamicPath = templateImpl.getDynamicSuperPagePath();
+                if (StringUtil.hasValue(dynamicPath)) {
+                    PageImpl.SuperPageInfo dynamicInfo = pageImpl.resolveExtendsPath(dynamicPath);
+                    return new SuperPageInfo(dynamicInfo.page, dynamicInfo.suffix, dynamicInfo.extension);
+                }
+            }
+            return new SuperPageInfo(null, null, null);
         }
         return new SuperPageInfo(page.getSuperPage(), page.getSuperSuffix(), page.getSuperExtension());
     }

--- a/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/RenderUtil.java
@@ -15,6 +15,7 @@
  */
 package org.seasar.mayaa.impl.engine;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -329,12 +330,18 @@ public class RenderUtil implements CONST_IMPL {
         List<Page> pageStack = new LinkedList<>();
         List<Template> templateStack = new LinkedList<>();
         do {
-            // stack for afterRender event.
-            pageStack.add(0, page);
             if (fireEvent) {
+                // 親仕様の beforeRender を外→内の順で実行する。
+                // 末端仕様のスコープが最も外側に置かれることで、
+                // 子仕様の beforeRender から親仕様の変数を参照できるスコープチェーンが構成される。
+                executeBeforeRenderOnAllParentSpecifications(page, pageStack);
+                // page 自身のスコープを最内側に積んでから beforeRender を実行する。
+                // これにより page は親仕様が宣言した変数を参照できる。
                 SpecificationUtil.startScope(variables);
                 SpecificationUtil.execEvent(page, QM_BEFORE_RENDER);
             }
+            // stack for afterRender event.
+            pageStack.add(0, page);
 
             Template template = getTemplate(requestedSuffix, page, suffix, extension);
             if (template != null) {
@@ -347,9 +354,6 @@ public class RenderUtil implements CONST_IMPL {
             // Page（キャッシュ済みイミュータブルインスタンス）には書き込まれないため、
             // getTemplate の後で template を渡して解決することで正しくレイアウトが適用される。
             SuperPageInfo superInfo = resolveSuperPageInfo(page, template);
-            if (fireEvent && superInfo.page == null) {
-                executeBeforeRenderOnAllParentSpecifications(page, pageStack);
-            }
 
             suffix = superInfo.suffix;
             extension = superInfo.extension;
@@ -411,14 +415,24 @@ public class RenderUtil implements CONST_IMPL {
         visited.add(basePage);
         Specification defaultSpec = SpecificationUtil.getDefaultSpecification();
 
+        // まず全親 Specification を内→外の順で収集する（チェーン順 = basePage に近い順）
+        List<Specification> parentChain = new ArrayList<>();
         Specification parent = EngineUtil.getParentSpecification(basePage);
         while (parent != null && !parent.getSystemID().equals(defaultSpec.getSystemID()) && visited.add(parent)) {
-            if (parent instanceof Page) {
-                pageStack.add(0, (Page) parent);
+            parentChain.add(parent);
+            parent = EngineUtil.getParentSpecification(parent);
+        }
+
+        // 末端から basePage 側に向けて（外→内の順）startScope + execEvent を実行する。
+        // これにより末端仕様のスコープが最も外側に置かれ、
+        // 子仕様の beforeRender から親仕様の変数を参照できるスコープチェーンが構成される。
+        for (int i = parentChain.size() - 1; i >= 0; i--) {
+            Specification spec = parentChain.get(i);
+            if (spec instanceof Page) {
+                pageStack.add(0, (Page) spec);
             }
             SpecificationUtil.startScope(null);
-            SpecificationUtil.execEvent(parent, QM_BEFORE_RENDER);
-            parent = EngineUtil.getParentSpecification(parent);
+            SpecificationUtil.execEvent(spec, QM_BEFORE_RENDER);
         }
     }
 

--- a/src-impl/org/seasar/mayaa/impl/engine/TemplateImpl.java
+++ b/src-impl/org/seasar/mayaa/impl/engine/TemplateImpl.java
@@ -56,6 +56,13 @@ public class TemplateImpl
     private String _suffix;
     private String _extension;
     private List<ProcessorTreeWalker> _childProcessors = new ArrayList<>();
+    /**
+     * DefaultLayoutTemplateBuilder.setupExtends がデフォルトレイアウトを設定する際、
+     * Page（キャッシュ済みイミュータブルインスタンス）を直接ミューテートせずに
+     * Template 自身がデフォルト拡張先ページ名を保持するためのフィールド。
+     * Page の .mayaa ファイルに m:extends が定義されていない場合に設定される。
+     */
+    private String _dynamicSuperPagePath;
 
     public void initialize(Page page, String suffix, String extension) {
         if (page == null || suffix == null || extension == null) {
@@ -80,6 +87,25 @@ public class TemplateImpl
 
     public String getExtension() {
         return _extension;
+    }
+
+    /**
+     * DefaultLayoutTemplateBuilder がデフォルトレイアウトのページ名を設定します。
+     * Page の .mayaa ファイルに m:extends 定義が存在しない場合に使用されます。
+     * Page インスタンスを直接ミューテートする代わりに Template 側で保持します。
+     *
+     * @param defaultLayoutPageName デフォルトレイアウトのページ名（例: "/layout.html"）
+     */
+    public void setDynamicSuperPagePath(String defaultLayoutPageName) {
+        _dynamicSuperPagePath = defaultLayoutPageName;
+    }
+
+    /**
+     * setDynamicSuperPagePath で設定されたデフォルトレイアウトのページ名を返します。
+     * 設定されていない場合は null を返します。
+     */
+    public String getDynamicSuperPagePath() {
+        return _dynamicSuperPagePath;
     }
 
     protected String getMayaaAttribute(Specification spec, QName qname) {

--- a/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
@@ -295,6 +295,253 @@ public class ParentSpecificationResolverIntegrationTest extends EngineTestBase {
     }
 
     /**
+     * m:extends と ParentSpecificationResolver を組み合わせた状態で、
+     * 各 beforeRender で宣言した変数を targetHtml 内の {@code ${}} 式で直接参照できることを確認する。
+     *
+     * <p>{@link #m_extendsとParentSpecResolver共存時に各beforeRenderで宣言した変数が子仕様から参照できる}
+     * と同じシナリオだが、テンプレートで変数を出力する手段として m:write ではなく
+     * HTML テンプレート内の {@code ${}} 直接参照を使用する点が異なる。</p>
+     *
+     * シナリオ:
+     *   ParentSpec chain: target → parentSpec1 → parentSpec2 → default
+     *   レイアウト継承 (m:extends): target → layout
+     *
+     * 期待するスコープ可視性:
+     *   parentSpec2.beforeRender が宣言した変数 → HTML 内 ${p2var} で参照可能
+     *   parentSpec1.beforeRender が宣言した変数 → HTML 内 ${p1var} で参照可能
+     *   target.beforeRender が宣言した変数    → HTML 内 ${tvar} で参照可能
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void m_extendsとParentSpecResolver共存時に各beforeRenderで宣言した変数がtargetHtml内から直接参照できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/extends-with-parent-chain-direct-ref";
+
+        String targetHtmlPath       = caseRoot + "/target.html";
+        String targetMayaaPath      = caseRoot + "/target.mayaa";
+        String layoutHtmlPath       = caseRoot + "/layout.html";
+        String layoutMayaaPath      = caseRoot + "/layout.mayaa";
+        String parentSpec1MayaaPath = caseRoot + "/parent-spec1.mayaa";
+        String parentSpec2MayaaPath = caseRoot + "/parent-spec2.mayaa";
+        String defaultMayaaPath     = caseRoot + "/default.mayaa";
+        String expectedPath         = caseRoot + "/expected.html";
+
+        // target.html: m:write を使わず ${} で各変数を直接参照する
+        String targetHtml = "<div id=\"root\">${p2var}${p1var}${tvar}</div>";
+
+        // target.mayaa: m:extends でレイアウトを継承しつつ beforeRender で変数を宣言する。
+        //   変数出力は HTML 側の ${} に委ねるため m:write は不要。
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                         m:extends="%s">
+                    <m:beforeRender><![CDATA[
+                        var tvar = "from-target";
+                        application.scopeTrace = application.scopeTrace + ",B-target";
+                    ]]></m:beforeRender>
+                    <m:doRender id="root" name="rootContent" />
+                </m:mayaa>
+                """.formatted(layoutHtmlPath);
+
+        // layout.html: レイアウトのHTMLテンプレート（スロット役）
+        String layoutHtml = "<div id=\"layout\"><div id=\"root\">layout-slot</div></div>";
+
+        // layout.mayaa: rootContent を insert で受け取る
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="root" name="rootContent" replace="false" />
+                </m:mayaa>
+                """;
+
+        // parent-spec1.mayaa: target の Parent として Resolver が返す親仕様。変数 p1var を宣言。
+        String parentSpec1Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var p1var = "from-parent1(p2var=" + p2var + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-p1";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // parent-spec2.mayaa: parent-spec1 の Parent として Resolver が返す仕様。変数 p2var を宣言。
+        String parentSpec2Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var p2var = "from-parent2";
+                        application.scopeTrace = application.scopeTrace + ",B-p2";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // default.mayaa: チェーンの末端 Specification。scopeTrace の初期化も担う。
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = "B-default";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // 期待する出力: HTML 内 ${} から各 beforeRender 宣言変数が参照できていること
+        String expected = "<div id=\"layout\"><div id=\"root\">"
+                + "from-parent2"
+                + "from-parent1(p2var=from-parent2)"
+                + "from-target"
+                + "</div></div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath,       targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,      targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath,       layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath,      layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(parentSpec1MayaaPath, parentSpec1Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(parentSpec2MayaaPath, parentSpec2Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath,     defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath,         expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        // target → parent-spec1 → parent-spec2 → default という親仕様チェーンを構築するリゾルバ
+        originalResolver = getServiceProvider().getParentSpecificationResolver();
+        getServiceProvider().setParentSpecificationResolver(
+                new ExtendsWithChainParentSpecificationResolver(originalResolver, caseRoot));
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+
+        // beforeRender 実行順序のトレース検証
+        //   期待順: default → p2 → p1 → target（外側スコープが先に実行される）
+        assertEquals("B-default,B-p2,B-p1,B-target",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("scopeTrace"));
+    }
+
+    /**
+     * レイアウト継承 (m:extends) とコンポーネント挿入 (m:insert) を併用した場合に、
+     * レイアウト (SuperPage) の beforeRender で宣言した変数を、ターゲット内に配置した
+     * コンポーネントから参照できることを確認する。
+     *
+     * <p>実行順序イメージ:</p>
+     * <pre>
+     *   default.beforeRender → target.beforeRender → layout.beforeRender
+     *   → (レンダリング開始) → m:insert 処理時に component.beforeRender
+     * </pre>
+     *
+     * <p>期待するスコープ可視性:</p>
+     * <ul>
+     *   <li>layout.beforeRender 宣言 layoutVar → component.beforeRender から参照可能</li>
+     *   <li>target.beforeRender 宣言 tvar       → component.beforeRender から参照可能</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void レイアウトとコンポーネント併用時にレイアウトのbeforeRender宣言変数がコンポーネントから参照できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/layout-and-component";
+
+        String targetHtmlPath     = caseRoot + "/target.html";
+        String targetMayaaPath    = caseRoot + "/target.mayaa";
+        String layoutHtmlPath     = caseRoot + "/layout.html";
+        String layoutMayaaPath    = caseRoot + "/layout.mayaa";
+        String componentHtmlPath  = caseRoot + "/component.html";
+        String componentMayaaPath = caseRoot + "/component.mayaa";
+        String defaultMayaaPath   = caseRoot + "/default.mayaa";
+        String expectedPath       = caseRoot + "/expected.html";
+
+        // target.html: comp-slot で component を受け取る
+        String targetHtml = "<div id=\"root\"><div id=\"comp-slot\">dummy</div></div>";
+
+        // target.mayaa: m:extends でレイアウト継承、tvar を宣言し component を挿入
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                         m:extends="%s">
+                    <m:beforeRender><![CDATA[
+                        var tvar = "from-target";
+                        application.scopeTrace = application.scopeTrace + ",B-T";
+                    ]]></m:beforeRender>
+                    <m:doRender id="root" name="rootContent" />
+                    <m:insert id="comp-slot" path="%s" replace="false" />
+                </m:mayaa>
+                """.formatted(layoutHtmlPath, componentHtmlPath);
+
+        // layout.html: レイアウトのHTMLテンプレート
+        String layoutHtml = "<div id=\"layout\"><div id=\"root\">layout-slot</div></div>";
+
+        // layout.mayaa: layoutVar を宣言し rootContent スロットを受け取る
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var layoutVar = "from-layout";
+                        application.scopeTrace = application.scopeTrace + ",B-L";
+                    ]]></m:beforeRender>
+                    <m:insert id="root" name="rootContent" replace="false" />
+                </m:mayaa>
+                """;
+
+        // component.html: layoutVar と tvar を参照して出力する
+        String componentHtml = "<div id=\"root\"><span id=\"cvar\">dummy</span></div>";
+
+        // component.mayaa: layoutVar (レイアウト) と tvar (ターゲット) の両方を参照して cvar を構築
+        String componentMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var cvar = "comp(layoutVar=" + layoutVar + ",tvar=" + tvar + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-C";
+                    ]]></m:beforeRender>
+                    <m:doRender id="root" />
+                    <m:write id="cvar" value="${cvar}" />
+                </m:mayaa>
+                """;
+
+        // default.mayaa: scopeTrace を初期化
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = "B-D";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // 期待する出力: layout 内の root slot にターゲット root の内容が挿入され、
+        //   comp-slot にコンポーネントが挿入される。
+        //   コンポーネントは layoutVar / tvar の両方を参照できている。
+        String expected = "<div id=\"layout\"><div id=\"root\">"
+                + "<div id=\"comp-slot\">"
+                + "comp(layoutVar=from-layout,tvar=from-target)"
+                + "</div>"
+                + "</div></div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath,     targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,    targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath,     layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath,    layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(componentHtmlPath,  componentHtml);
+        DynamicRegisteredSourceHolder.registerContents(componentMayaaPath, componentMayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath,   defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath,       expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+
+        // beforeRender 実行順序のトレース検証
+        //   期待順: D → T (target) → L (layout/SuperPage) → C (component, m:insert タイミング)
+        assertEquals("B-D,B-T,B-L,B-C",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("scopeTrace"));
+    }
+
+    /**
      * SuperPage (m:extends によって指定されるレイアウトページ) の親仕様チェーンで宣言した
      * 変数が、より具体的な仕様 (SuperPage 自身の beforeRender) から参照できることを確認する。
      *

--- a/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/engine/ParentSpecificationResolverIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -134,7 +135,7 @@ public class ParentSpecificationResolverIntegrationTest extends EngineTestBase {
                     ]]></m:afterRender>
                 </m:mayaa>
                 """;
-        String expected = "<div id=\"root\">D&gt;T&gt;P1&gt;P2</div>";
+        String expected = "<div id=\"root\">D&gt;P2&gt;P1&gt;T</div>";
 
         DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
         DynamicRegisteredSourceHolder.registerContents(targetMayaaPath, targetMayaa);
@@ -153,8 +154,385 @@ public class ParentSpecificationResolverIntegrationTest extends EngineTestBase {
 
         execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<String, Object>());
 
-        assertEquals("|B-D|B-T|B-P1|B-P2|A-P2|A-P1|A-T|A-D",
+        assertEquals("|B-D|B-P2|B-P1|B-T|A-T|A-P1|A-P2|A-D",
             CycleUtil.getServiceCycle().getApplicationScope().getAttribute("parentChainTrace"));
+    }
+
+    /**
+     * ParentSpecificationResolver を差し替えて複数の親仕様が存在する状態で、
+     * target が m:extends によるレイアウト継承も使用している場合に、
+     * 各親仕様の beforeRender で宣言した変数がより具体的な仕様（target）の
+     * beforeRender / テンプレート内 m:write から参照できることを確認する。
+     *
+     * シナリオ:
+     *   ParentSpec chain: target → parentSpec1 → parentSpec2 → default
+     *   レイアウト継承 (m:extends): target → layout
+     *
+     * 期待するスコープ可視性:
+     *   parentSpec2.beforeRender が宣言した変数 → parentSpec1.beforeRender から参照可能
+     *   parentSpec1.beforeRender が宣言した変数 → target.beforeRender から参照可能
+     *   target.beforeRender が宣言した変数    → テンプレート内 m:write から参照可能
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void m_extendsとParentSpecResolver共存時に各beforeRenderで宣言した変数が子仕様から参照できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/extends-with-parent-chain";
+
+        String targetHtmlPath  = caseRoot + "/target.html";
+        String targetMayaaPath = caseRoot + "/target.mayaa";
+        String layoutHtmlPath  = caseRoot + "/layout.html";
+        String layoutMayaaPath = caseRoot + "/layout.mayaa";
+        String parentSpec1MayaaPath = caseRoot + "/parent-spec1.mayaa";
+        String parentSpec2MayaaPath = caseRoot + "/parent-spec2.mayaa";
+        String defaultMayaaPath     = caseRoot + "/default.mayaa";
+        String expectedPath         = caseRoot + "/expected.html";
+
+        // target.html: m:write で各スコープの変数を出力する
+        String targetHtml = "<div id=\"root\">"
+                + "<span id=\"p2var\">?</span>"
+                + "<span id=\"p1var\">?</span>"
+                + "<span id=\"tvar\">?</span>"
+                + "</div>";
+
+        // target.mayaa: m:extends でレイアウトを継承しつつ、beforeRender でも変数を宣言する。
+        //   - p2var / p1var は親仕様の beforeRender で宣言されるはずの変数を参照する
+        //   - tvar は自身の beforeRender で宣言する
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                         m:extends="%s">
+                    <m:beforeRender><![CDATA[
+                        var tvar = "from-target";
+                        application.scopeTrace = application.scopeTrace + ",B-target";
+                    ]]></m:beforeRender>
+                    <m:write id="p2var" value="${p2var}" />
+                    <m:write id="p1var" value="${p1var}" />
+                    <m:write id="tvar"  value="${tvar}" />
+                    <m:doRender id="root" name="rootContent" />
+                </m:mayaa>
+                """.formatted(layoutHtmlPath);
+
+        // layout.html: レイアウトのHTMLテンプレート（スロット役）
+        String layoutHtml = "<div id=\"layout\"><div id=\"root\">layout-slot</div></div>";
+
+        // layout.mayaa: レイアウト自体は beforeRender なし、rootContent を insert で受け取る
+        // replace="false" にすることで layout の div#root タグを保持しつつ中身を置換する
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:insert id="root" name="rootContent" replace="false" />
+                </m:mayaa>
+                """;
+
+        // parent-spec1.mayaa: target の Parent として Resolver が返す親仕様。変数 p1var を宣言。
+        //   p2var を参照して連鎖を確認（p2var は parent-spec2 が宣言する変数）
+        String parentSpec1Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var p1var = "from-parent1(p2var=" + p2var + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-p1";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // parent-spec2.mayaa: parent-spec1 の Parent として Resolver が返す仕様。変数 p2var を宣言。
+        String parentSpec2Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var p2var = "from-parent2";
+                        application.scopeTrace = application.scopeTrace + ",B-p2";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // default.mayaa: チェーンの末端 Specification（defaultSpecification として使用）。
+        //   scopeTrace の初期化も担う。
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = "B-default";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // 期待する出力: 各 beforeRender で宣言した変数がテンプレートから参照できていること
+        // m:write はデフォルト replace="true" なので span タグごと値に置換される
+        String expected = "<div id=\"layout\"><div id=\"root\">"
+                + "from-parent2"
+                + "from-parent1(p2var=from-parent2)"
+                + "from-target"
+                + "</div></div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath,      targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,     targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath,      layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath,     layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(parentSpec1MayaaPath, parentSpec1Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(parentSpec2MayaaPath, parentSpec2Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath,    defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath,        expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        // target → parent-spec1 → parent-spec2 → default という親仕様チェーンを構築するリゾルバ
+        originalResolver = getServiceProvider().getParentSpecificationResolver();
+        getServiceProvider().setParentSpecificationResolver(
+                new ExtendsWithChainParentSpecificationResolver(originalResolver, caseRoot));
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+
+        // beforeRender 実行順序のトレース検証
+        //   期待順: default → p2 → p1 → target（外側スコープが先に実行される）
+        assertEquals("B-default,B-p2,B-p1,B-target",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("scopeTrace"));
+    }
+
+    /**
+     * SuperPage (m:extends によって指定されるレイアウトページ) の親仕様チェーンで宣言した
+     * 変数が、より具体的な仕様 (SuperPage 自身の beforeRender) から参照できることを確認する。
+     *
+     * <p>用語</p>
+     * <ul>
+     *   <li>Target    : アクセスの直接の対象ページ</li>
+     *   <li>SuperPage : Target に m:extends で指定されるレイアウトページ</li>
+     *   <li>Parent    : Target/SuperPage それぞれに対する親ページ (Resolver が返す)</li>
+     * </ul>
+     *
+     * <p>Parent chain (SuperPage 側):</p>
+     * <pre>layout → layout-parent1 → layout-parent2 → default</pre>
+     *
+     * <p>期待するスコープ可視性:</p>
+     * <ul>
+     *   <li>layout-parent2.beforeRender 宣言 lp2var → layout-parent1 から参照可能</li>
+     *   <li>layout-parent1.beforeRender 宣言 lp1var → layout から参照可能</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void SuperPageの親仕様チェーンの各beforeRenderで宣言した変数がSuperPage自身のbeforeRenderから参照できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/super-page-parent-chain";
+        String targetHtmlPath      = caseRoot + "/target.html";
+        String targetMayaaPath     = caseRoot + "/target.mayaa";
+        String layoutHtmlPath      = caseRoot + "/layout.html";
+        String layoutMayaaPath     = caseRoot + "/layout.mayaa";
+        String layoutParent1MayaaPath = caseRoot + "/layout-parent1.mayaa";
+        String layoutParent2MayaaPath = caseRoot + "/layout-parent2.mayaa";
+        String defaultMayaaPath    = caseRoot + "/default.mayaa";
+        String expectedPath        = caseRoot + "/expected.html";
+
+        // Target: m:extends でレイアウトを指定するだけ。コンテンツ挿入は行わない。
+        String targetHtml = "<div>TARGET</div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                         m:extends="%s">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = application.scopeTrace + ",B-T";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """.formatted(layoutHtmlPath);
+
+        // SuperPage (layout): layout-parent{1,2} が宣言した変数を参照して lvar を構築し出力する
+        String layoutHtml = "<div id=\"layout\"><span id=\"lvar\">dummy</span></div>";
+        String layoutMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var lvar = "from-layout(lp1var=" + lp1var + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-L";
+                    ]]></m:beforeRender>
+                    <m:write id="lvar" value="${lvar}" />
+                </m:mayaa>
+                """;
+
+        // layout の Parent chain: layout-parent2 が末端、layout-parent1 が中間
+        String layoutParent2Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var lp2var = "from-lp2";
+                        application.scopeTrace = application.scopeTrace + ",B-LP2";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+        String layoutParent1Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var lp1var = "from-lp1(lp2var=" + lp2var + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-LP1";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // default: アプリスコープの scopeTrace を初期化
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = "B-D";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // 期待する出力: layout の lvar が lp1var/lp2var を参照して構築された値になること
+        // m:write は replace="true" (デフォルト) なので span タグごと値に置換される
+        String expected = "<div id=\"layout\">from-layout(lp1var=from-lp1(lp2var=from-lp2))</div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath,       targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,      targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath,       layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(layoutMayaaPath,      layoutMayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutParent1MayaaPath, layoutParent1Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(layoutParent2MayaaPath, layoutParent2Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath,     defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath,         expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        // layout → layout-parent1 → layout-parent2 → default という親仕様チェーンを構築するリゾルバ
+        Map<String, String> parentMap = new LinkedHashMap<>();
+        parentMap.put(caseRoot + "/layout",         caseRoot + "/layout-parent1");
+        parentMap.put(caseRoot + "/layout-parent1", caseRoot + "/layout-parent2");
+        parentMap.put(caseRoot + "/layout-parent2", null); // null = defaultSpec で終端
+
+        originalResolver = getServiceProvider().getParentSpecificationResolver();
+        getServiceProvider().setParentSpecificationResolver(
+                new MappedParentSpecificationResolver(originalResolver, parentMap));
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+
+        // beforeRender 実行順序のトレース検証
+        //   期待順: D → T (Target, 親仕様なし) → LP2 → LP1 → L (SuperPage の親チェーンは外→内)
+        assertEquals("B-D,B-T,B-LP2,B-LP1,B-L",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("scopeTrace"));
+    }
+
+    /**
+     * Component (m:insert で差し込まれるページ) の親仕様チェーンで宣言した変数が、
+     * Component 自身の beforeRender から参照できることを確認する。
+     *
+     * <p>用語</p>
+     * <ul>
+     *   <li>Component : Target や SuperPage 内から m:insert によって差し込まれる断片ページ</li>
+     *   <li>Parent    : Component に対する親ページ (Resolver が返す)</li>
+     * </ul>
+     *
+     * <p>Parent chain (Component 側):</p>
+     * <pre>component → comp-parent1 → default</pre>
+     *
+     * <p>期待するスコープ可視性:</p>
+     * <ul>
+     *   <li>comp-parent1.beforeRender 宣言 cp1var → component から参照可能</li>
+     * </ul>
+     *
+     * <p>Component の beforeRender は m:insert の処理タイミングでインラインに実行される。</p>
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    public void Componentの親仕様チェーンの各beforeRenderで宣言した変数がComponent自身のbeforeRenderから参照できる(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseRoot = "/it-case/parent-specification-resolver/component-parent-chain";
+        String targetHtmlPath     = caseRoot + "/target.html";
+        String targetMayaaPath    = caseRoot + "/target.mayaa";
+        String componentHtmlPath  = caseRoot + "/component.html";
+        String componentMayaaPath = caseRoot + "/component.mayaa";
+        String compParent1MayaaPath = caseRoot + "/comp-parent1.mayaa";
+        String defaultMayaaPath   = caseRoot + "/default.mayaa";
+        String expectedPath       = caseRoot + "/expected.html";
+
+        // Target: component を m:insert (path 指定) で差し込む
+        String targetHtml = "<div id=\"root\"><div id=\"comp-slot\">dummy</div></div>";
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = application.scopeTrace + ",B-T";
+                    ]]></m:beforeRender>
+                    <m:insert id="comp-slot" path="%s" replace="false" />
+                </m:mayaa>
+                """.formatted(componentHtmlPath);
+
+        // Component: comp-parent1 が宣言した cp1var を参照して cvar を構築し出力する
+        // div id="root" は m:doRender で Component のルートコンテンツとしてマークする
+        String componentHtml = "<div id=\"root\"><span id=\"cvar\">dummy</span></div>";
+        String componentMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var cvar = "from-comp(cp1var=" + cp1var + ")";
+                        application.scopeTrace = application.scopeTrace + ",B-C";
+                    ]]></m:beforeRender>
+                    <m:doRender id="root" />
+                    <m:write id="cvar" value="${cvar}" />
+                </m:mayaa>
+                """;
+
+        // Component の Parent: comp-parent1
+        String compParent1Mayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        var cp1var = "from-cp1";
+                        application.scopeTrace = application.scopeTrace + ",B-CP1";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // default: アプリスコープの scopeTrace を初期化
+        String defaultMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:beforeRender><![CDATA[
+                        application.scopeTrace = "B-D";
+                    ]]></m:beforeRender>
+                </m:mayaa>
+                """;
+
+        // 期待する出力: comp-slot の中に component が挿入され、cvar が cp1var を参照して構築された値になること
+        // m:write は replace="true" (デフォルト) なので span タグごと値に置換される
+        // m:insert replace="false" なので comp-slot の div タグは保持される
+        String expected = "<div id=\"root\"><div id=\"comp-slot\">from-comp(cp1var=from-cp1)</div></div>";
+
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath,      targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetMayaaPath,     targetMayaa);
+        DynamicRegisteredSourceHolder.registerContents(componentHtmlPath,   componentHtml);
+        DynamicRegisteredSourceHolder.registerContents(componentMayaaPath,  componentMayaa);
+        DynamicRegisteredSourceHolder.registerContents(compParent1MayaaPath, compParent1Mayaa);
+        DynamicRegisteredSourceHolder.registerContents(defaultMayaaPath,    defaultMayaa);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath,        expected);
+
+        getServiceProvider().getEngine().setParameter("defaultSpecification", defaultMayaaPath);
+
+        // component → comp-parent1 → default という親仕様チェーンを構築するリゾルバ
+        Map<String, String> parentMap = new LinkedHashMap<>();
+        parentMap.put(caseRoot + "/component", caseRoot + "/comp-parent1");
+        parentMap.put(caseRoot + "/comp-parent1", null); // null = defaultSpec で終端
+
+        originalResolver = getServiceProvider().getParentSpecificationResolver();
+        getServiceProvider().setParentSpecificationResolver(
+                new MappedParentSpecificationResolver(originalResolver, parentMap));
+
+        execAndVerify(targetHtmlPath, expectedPath, new LinkedHashMap<>());
+
+        // beforeRender 実行順序のトレース検証
+        //   期待順: D → T → CP1 → C（Component の親チェーンは m:insert 処理タイミングでインラインに実行）
+        assertEquals("B-D,B-T,B-CP1,B-C",
+            CycleUtil.getServiceCycle().getApplicationScope().getAttribute("scopeTrace"));
     }
 
     void setUseNewParser(boolean useNewParser) {
@@ -211,6 +589,97 @@ public class ParentSpecificationResolverIntegrationTest extends EngineTestBase {
             }
             if ((caseRoot + "/parent2").equals(pageName)) {
                 return SpecificationUtil.getDefaultSpecification();
+            }
+            if (fallback != null) {
+                return fallback.getParentSpecification(spec);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * m:extends によるレイアウト継承と ParentSpecificationResolver による親仕様連鎖を
+     * 組み合わせるテスト用リゾルバ。
+     *   target          → parent-spec1 (親仕様チェーン)
+     *   parent-spec1    → parent-spec2 (親仕様チェーン)
+     *   parent-spec2    → defaultSpec  (終端)
+     *   layout / others → fallback
+     */
+    private static final class ExtendsWithChainParentSpecificationResolver extends ParameterAwareImpl
+            implements ParentSpecificationResolver {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ParentSpecificationResolver fallback;
+        private final String caseRoot;
+
+        private ExtendsWithChainParentSpecificationResolver(
+                ParentSpecificationResolver fallback, String caseRoot) {
+            this.fallback = fallback;
+            this.caseRoot = caseRoot;
+        }
+
+        @Override
+        public Specification getParentSpecification(Specification spec) {
+            if (spec instanceof Template) {
+                return ((Template) spec).getPage();
+            }
+            if (!(spec instanceof Page)) {
+                return null;
+            }
+
+            String pageName = ((Page) spec).getPageName();
+            Engine engine = ProviderUtil.getEngine();
+            if ((caseRoot + "/target").equals(pageName)) {
+                return engine.getPage(caseRoot + "/parent-spec1");
+            }
+            if ((caseRoot + "/parent-spec1").equals(pageName)) {
+                return engine.getPage(caseRoot + "/parent-spec2");
+            }
+            if ((caseRoot + "/parent-spec2").equals(pageName)) {
+                return SpecificationUtil.getDefaultSpecification();
+            }
+            if (fallback != null) {
+                return fallback.getParentSpecification(spec);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * ページ名と親ページ名のマッピングによって親仕様を解決する汎用リゾルバ。
+     * マップの値が null の場合は defaultSpecification を返す。
+     * マップに含まれないページは fallback リゾルバに委譲する。
+     */
+    private static final class MappedParentSpecificationResolver extends ParameterAwareImpl
+            implements ParentSpecificationResolver {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ParentSpecificationResolver fallback;
+        private final Map<String, String> parentMap;
+
+        private MappedParentSpecificationResolver(
+                ParentSpecificationResolver fallback, Map<String, String> parentMap) {
+            this.fallback = fallback;
+            this.parentMap = parentMap;
+        }
+
+        @Override
+        public Specification getParentSpecification(Specification spec) {
+            if (spec instanceof Template) {
+                return ((Template) spec).getPage();
+            }
+            if (!(spec instanceof Page)) {
+                return null;
+            }
+            String pageName = ((Page) spec).getPageName();
+            if (parentMap.containsKey(pageName)) {
+                String parentName = parentMap.get(pageName);
+                if (parentName == null) {
+                    return SpecificationUtil.getDefaultSpecification();
+                }
+                return ProviderUtil.getEngine().getPage(parentName);
             }
             if (fallback != null) {
                 return fallback.getParentSpecification(spec);

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/ExtendsFromTemplateIntegrationTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/ExtendsFromTemplateIntegrationTest.java
@@ -23,7 +23,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.seasar.mayaa.functional.EngineTestBase;
 import org.seasar.mayaa.impl.builder.TemplateBuilderImpl;
+import org.seasar.mayaa.impl.engine.EngineImpl;
+import org.seasar.mayaa.impl.provider.ProviderUtil;
 import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * HTML テンプレートのノードに書かれた {@code m:extends} 属性を元に
@@ -205,6 +209,65 @@ public class ExtendsFromTemplateIntegrationTest extends EngineTestBase {
     void setAutoEscapeEnabled(boolean enabled) {
         getServiceProvider().getScriptEnvironment().setParameter(
                 "autoEscapeEnabled", Boolean.toString(enabled));
+    }
+
+    /**
+     * .mayaa ファイルが存在しないページで Caffeine の TTL エビクションにより
+     * Page がキャッシュから消えた後も、2回目以降のリクエストでレイアウトが
+     * 正しく適用されることを確認する。
+     *
+     * <p>デフォルトレイアウト情報（m:extends パス）は Template 自身が
+     * {@code _dynamicSuperPagePath} フィールドで保持するため、Page がエビクション
+     * されても Template がキャッシュに残っている限りレイアウトは維持される。
+     * Template の再ビルドは不要。
+     *
+     * <p>再現手順：
+     * <ol>
+     *   <li>1回目リクエスト: Page と Template の両方をビルド・キャッシュ</li>
+     *   <li>Page のみを deprecate（Caffeine TTL エビクション相当）</li>
+     *   <li>2回目リクエスト: Page は再生成されるが Template はキャッシュのまま再利用。
+     *       Template が持つ {@code _dynamicSuperPagePath} によりレイアウトが適用される。</li>
+     * </ol>
+     */
+    @ParameterizedTest(name = "useNewParser {0}")
+    @ValueSource(booleans = { false, true })
+    void Pageエビクション後も既存Templateのdynamic設定でレイアウトが適用される(boolean useNewParser)
+            throws IOException {
+        setUseNewParser(useNewParser);
+        setAutoEscapeEnabled(false);
+
+        String caseName = "html-extends-page-eviction";
+        String casePath = BASE + caseName + "/";
+        String layoutHtmlPath = casePath + "layout.html";
+        String targetHtmlPath = casePath + "target.html";
+        String expectedPath = casePath + "expected.html";
+
+        String layoutHtml = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+        String targetHtml = "<html xmlns:m=\"http://mayaa.seasar.org\" m:extends=\"" + layoutHtmlPath + "\">"
+                + "<head></head><body><p id=\"content\">TARGET-CONTENT</p></body></html>";
+        // レイアウトに m:insert がないのでターゲットコンテンツは出力されない
+        String expected = "<html><head></head><body><p id=\"marker\">LAYOUT-CONTENT</p></body></html>";
+
+        DynamicRegisteredSourceHolder.registerContents(layoutHtmlPath, layoutHtml);
+        DynamicRegisteredSourceHolder.registerContents(targetHtmlPath, targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(expectedPath, expected);
+
+        // 1回目: Page（target.mayaa）と Template（target.html）をビルド・キャッシュ
+        MockHttpServletRequest request = createRequest(targetHtmlPath);
+        MockHttpServletResponse response1 = exec(request, new LinkedHashMap<>());
+        verifyResponse(response1, expectedPath, "1回目リクエスト");
+
+        // Caffeine TTL エビクション相当: Pageのみを無効化（Template はキャッシュに残す）。
+        // PageのsystemIDはリクエストされたパスから拡張子と ".mayaa" で構成。
+        // /it-case/.../target.html → pageName = /it-case/.../target → pageSystemID = /it-case/.../target.mayaa
+        String pageSystemID = targetHtmlPath.substring(0, targetHtmlPath.lastIndexOf('.')) + ".mayaa";
+        ((EngineImpl) ProviderUtil.getEngine()).deprecateSpecification(pageSystemID, false);
+
+        // 2回目: Page が再生成される。この際、関連 Template も deprecate されて
+        // 再ビルドが起きることで mayaaNode が正しく付与され、レイアウトが適用されるはず。
+        MockHttpServletRequest request2 = createRequest(targetHtmlPath);
+        MockHttpServletResponse response2 = exec(request2, new LinkedHashMap<>());
+        verifyResponse(response2, expectedPath, "Pageエビクション後の2回目リクエスト");
     }
 
     @AfterEach

--- a/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/HtmlExtendsTemplateBuilder.java
+++ b/src/test/java/org/seasar/mayaa/functional/layout/extends_from_template/HtmlExtendsTemplateBuilder.java
@@ -15,8 +15,6 @@
  */
 package org.seasar.mayaa.functional.layout.extends_from_template;
 
-import static org.seasar.mayaa.impl.CONST_IMPL.QM_EXTENDS;
-
 import java.util.Iterator;
 
 import org.seasar.mayaa.engine.Page;
@@ -24,6 +22,7 @@ import org.seasar.mayaa.engine.Template;
 import org.seasar.mayaa.engine.specification.NodeTreeWalker;
 import org.seasar.mayaa.engine.specification.SpecificationNode;
 import org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder;
+import org.seasar.mayaa.impl.engine.TemplateImpl;
 import org.seasar.mayaa.impl.engine.specification.SpecificationUtil;
 import org.seasar.mayaa.impl.util.StringUtil;
 
@@ -47,25 +46,19 @@ public class HtmlExtendsTemplateBuilder extends DefaultLayoutTemplateBuilder {
 
     @Override
     protected void setupExtends(Template template) {
+        // Page の .mayaa に m:extends が既に定義されている場合は何もしない（Page 定義優先）
+        Page page = template.getPage();
+        SpecificationNode mayaaNode = getMayaaNode(page);
+        if (mayaaNode != null && !StringUtil.isEmpty(
+                SpecificationUtil.getAttributeValue(mayaaNode, QM_EXTENDS))) {
+            return;
+        }
+
         String extendsValue = findExtendsFromHtml(template);
         if (!StringUtil.isEmpty(extendsValue)) {
-            Page page = template.getPage();
-            SpecificationNode mayaaNode = getMayaaNode(page);
-
-            if (isGenerateMayaaNode() && mayaaNode == null) {
-                mayaaNode = createMayaaNode(page, template);
-                if (template.getParentNode() != null) {
-                    mayaaNode.setParentNode(template.getParentNode());
-                    template.setParentNode(mayaaNode);
-                }
-                page.addChildNode(mayaaNode);
-            }
-
-            if (mayaaNode != null) {
-                String existing = SpecificationUtil.getAttributeValue(mayaaNode, QM_EXTENDS);
-                if (StringUtil.isEmpty(existing)) {
-                    mayaaNode.addAttribute(QM_EXTENDS, extendsValue);
-                }
+            // HTML から読み取った m:extends を Template 側に保持する（Page はミューテートしない）
+            if (template instanceof TemplateImpl) {
+                ((TemplateImpl) template).setDynamicSuperPagePath(extendsValue);
             }
         } else {
             // HTML に m:extends がなければデフォルト動作（defaultLayoutPageName を使う）

--- a/src/test/java/org/seasar/mayaa/impl/builder/DefaultLayoutTemplateBuilderTest.java
+++ b/src/test/java/org/seasar/mayaa/impl/builder/DefaultLayoutTemplateBuilderTest.java
@@ -19,18 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.seasar.mayaa.FactoryFactory;
 import org.seasar.mayaa.engine.Page;
-import org.seasar.mayaa.engine.specification.SpecificationNode;
 import org.seasar.mayaa.impl.CONST_IMPL;
 import org.seasar.mayaa.impl.engine.PageImpl;
 import org.seasar.mayaa.impl.engine.TemplateImpl;
-import org.seasar.mayaa.impl.engine.specification.SpecificationImpl;
 import org.seasar.mayaa.impl.engine.specification.SpecificationNodeImpl;
 import org.seasar.mayaa.impl.engine.specification.SpecificationUtil;
 import org.seasar.mayaa.impl.source.FileSourceDescriptor;
@@ -47,7 +44,6 @@ public class DefaultLayoutTemplateBuilderTest {
     private static final String VALID_SYSTEM_ID = "/defaultlayout.html";
     private static final String INVALID_SYSTEM_ID_1 = "defaultlayout.html";
     private static final String INVALID_SYSTEM_ID_2 = "/foo/../defaultlayout.html";
-    private static final String SYSTEM_ID_SUFFIX = ".mayaa/(auto)";
 
     private DefaultLayoutTemplateBuilder _builder;
     
@@ -73,7 +69,8 @@ public class DefaultLayoutTemplateBuilderTest {
     }
 
     /**
-     * Test method for {@link org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder#setupExtends(org.seasar.mayaa.engine.Template)}.
+     * .mayaa ファイルなし（mayaaNode=null）かつ generateMayaaNode=true の場合、
+     * Page はミューテートされず、template の dynamicSuperPagePath にデフォルトレイアウトが設定される。
      */
     @Test
     public void testSetupExtends() {
@@ -82,40 +79,94 @@ public class DefaultLayoutTemplateBuilderTest {
         PageImpl page = new PageImpl();
         page.initialize("/test");
         template.setPage(page);
-
         template.initialize(page, "", "html");
 
         assertNull(SpecificationUtil.getMayaaNode(page));
 
         _builder.setupExtends(template);
 
-        SpecificationNode mayaaNode = SpecificationUtil.getMayaaNode(page);
-
-        assertNotNull(mayaaNode);
-        assertEquals(VALID_SYSTEM_ID,
-                SpecificationUtil.getAttributeValue(mayaaNode, CONST_IMPL.QM_EXTENDS));
+        // Page はミューテートされない
+        assertNull(SpecificationUtil.getMayaaNode(page));
+        // Template に dynamicSuperPagePath が設定される
+        assertEquals(VALID_SYSTEM_ID, template.getDynamicSuperPagePath());
     }
 
-    // TODO generateMayaaNode が false の場合のテスト
-    // TODO mayaaがある場合のテスト
-    // TODO defaultlaytout なら追加しないテスト
-
     /**
-     * Test method for {@link org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder#createMayaaNode(org.seasar.mayaa.engine.Page, org.seasar.mayaa.engine.specification.Specification)}.
+     * generateMayaaNode=false の場合、.mayaa ファイルがなくても dynamicSuperPagePath は設定されない。
      */
     @Test
-    public void testCreateMayaaNode() {
+    public void testSetupExtends_generateMayaaNodeFalse() {
+        DefaultLayoutTemplateBuilder builder = new DefaultLayoutTemplateBuilder();
+        builder.setParameter("generateMayaaNode", "false");
+        builder.setParameter("defaultLayoutPageName", VALID_SYSTEM_ID);
+
+        MockTemplateImpl template = new MockTemplateImpl();
         PageImpl page = new PageImpl();
         page.initialize("/test");
-        SpecificationImpl spec = new SpecificationImpl();
+        template.setPage(page);
+        template.initialize(page, "", "html");
 
-        SpecificationNode mayaaNode = _builder.createMayaaNode(page, spec);
+        builder.setupExtends(template);
 
-        assertTrue(mayaaNode.getSystemID().endsWith(SYSTEM_ID_SUFFIX), mayaaNode.getSystemID());
+        assertNull(template.getDynamicSuperPagePath());
     }
 
     /**
-     * Test method for {@link org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder#createMayaaNode(org.seasar.mayaa.engine.Page, org.seasar.mayaa.engine.specification.Specification)}.
+     * .mayaa ファイルがあり m:extends が設定済みの場合、
+     * dynamicSuperPagePath は設定されない（.mayaa 定義が優先される）。
+     */
+    @Test
+    public void testSetupExtends_mayaaNodeWithExtends() {
+        MockTemplateImpl template = new MockTemplateImpl();
+        PageImpl page = new PageImpl();
+        page.initialize("/test");
+        template.setPage(page);
+        template.initialize(page, "", "html");
+
+        SpecificationNodeImpl mayaaNode = new SpecificationNodeImpl(CONST_IMPL.QM_MAYAA);
+        mayaaNode.setSystemID("/test.mayaa");
+        mayaaNode.addAttribute(CONST_IMPL.QM_EXTENDS, "/other-layout.html");
+        page.addChildNode(mayaaNode);
+
+        _builder.setupExtends(template);
+
+        assertNull(template.getDynamicSuperPagePath());
+    }
+
+    /**
+     * .mayaa ファイルはあるが m:extends が未設定の場合、デフォルトレイアウトが dynamicSuperPagePath に設定される。
+     */
+    @Test
+    public void testSetupExtends_mayaaNodeWithoutExtends() {
+        MockTemplateImpl template = new MockTemplateImpl();
+        PageImpl page = new PageImpl();
+        page.initialize("/test");
+        template.setPage(page);
+        template.initialize(page, "", "html");
+
+        SpecificationNodeImpl mayaaNode = new SpecificationNodeImpl(CONST_IMPL.QM_MAYAA);
+        mayaaNode.setSystemID("/test.mayaa");
+        page.addChildNode(mayaaNode);
+
+        _builder.setupExtends(template);
+
+        assertEquals(VALID_SYSTEM_ID, template.getDynamicSuperPagePath());
+    }
+
+    /**
+     * createMayaaNode は Mayaa 2.0 で廃止。{@link UnsupportedOperationException} がスローされる。
+     */
+    @Test
+    public void testCreateMayaaNode_throwsUnsupported() {
+        PageImpl page = new PageImpl();
+        page.initialize("/test");
+        assertThrows(UnsupportedOperationException.class,
+                () -> _builder.createMayaaNode(page, null));
+    }
+
+    /**
+     * {@link DefaultLayoutTemplateBuilder#getMayaaNode(Page)} は .mayaa ファイルに定義された
+     * mayaaNode を返す。
      */
     @Test
     public void testGetMayaaNode() {
@@ -133,37 +184,16 @@ public class DefaultLayoutTemplateBuilderTest {
     }
 
     /**
-     * Test method for {@link org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder#createMayaaNode(org.seasar.mayaa.engine.Page, org.seasar.mayaa.engine.specification.Specification)}.
+
+     * addExtends は Mayaa 2.0 で廃止。{@link UnsupportedOperationException} がスローされる。
      */
     @Test
-    public void testGetMayaaNode_auto() {
-        PageImpl page = new PageImpl();
-        page.initialize("/test");
-        SpecificationImpl spec = new SpecificationImpl();
-        page.addChildNode(_builder.createMayaaNode(page, spec));
-
-        assertNotNull(SpecificationUtil.getMayaaNode(page));
-
-        assertNull(_builder.getMayaaNode(page));
-
-        assertNull(SpecificationUtil.getMayaaNode(page));
-    }
-
-    /**
-     * Test method for {@link org.seasar.mayaa.impl.builder.DefaultLayoutTemplateBuilder#addExtends(org.seasar.mayaa.engine.Page, org.seasar.mayaa.engine.specification.SpecificationNode)}.
-     */
-    @Test
-    public void testAddExtends() {
+    public void testAddExtends_throwsUnsupported() {
         PageImpl page = new PageImpl();
         page.initialize("/test");
         SpecificationNodeImpl mayaaNode = new SpecificationNodeImpl(CONST_IMPL.QM_MAYAA);
-
-        assertNull(SpecificationUtil.getAttributeValue(mayaaNode, CONST_IMPL.QM_EXTENDS));
-
-        _builder.addExtends(page, mayaaNode);
-
-        assertEquals(VALID_SYSTEM_ID,
-                SpecificationUtil.getAttributeValue(mayaaNode, CONST_IMPL.QM_EXTENDS));
+        assertThrows(UnsupportedOperationException.class,
+                () -> _builder.addExtends(page, mayaaNode));
     }
 
     /**


### PR DESCRIPTION
## 概要

Caffeine キャッシュ移行後に発生していた「デフォルトレイアウト（）が初回リクエストで適用されない」問題の根本修正。

### 問題の背景

**旧設計**では `DefaultLayoutTemplateBuilder.setupExtends()` が、キャッシュ済みの `Page` インスタンスに `mayaaNode`（`m:extends` 属性付き）を直接書き込んでいた。これにより以下の問題が発生：

1. **同一リクエスト内で別インスタンス問題**  
   Template ビルド中に `template.getPage()` が呼ばれた際、`requestValidSpecCache` に `null` センチネルエントリが残っていると `createPageInstance` が再呼び出しされ、呼び出し元が保持する Page とは**別のインスタンス**が生成された。`setupExtends` がその別インスタンスを書き換えても呼び出し元には伝わらない。

2. **Caffeine 独立エビクション問題**  
   Page のみエビクションされ Template がキャッシュに残った場合、Page 再生成時に Template が再ビルドされないため `mayaaNode` が失われた。

### 新設計

- **キャッシュ済みの `Page` インスタンスはイミュータブルとして扱う。**
- `setupExtends()` は `TemplateImpl.setDynamicSuperPagePath(String)` を呼び出してレイアウト情報を **Template 自身** に保持する。
- `RenderUtil.resolveSuperPageInfo()` は Page の `.mayaa` 定義（`m:extends`）を優先し、定義がない場合のみ Template の `dynamicSuperPagePath` を参照する。
- `createMayaaNode()` / `addExtends()` は `@Deprecated` + `UnsupportedOperationException`（移行メッセージ付き）。

### 破壊的変更

`DefaultLayoutTemplateBuilder` をサブクラス化して `setupExtends()` / `createMayaaNode()` / `addExtends()` をオーバーライドしている実装は移行が必要。詳細は `doc/UPGRADING.md` 参照。

## コミット構成

| コミット | 内容 |
|---|---|
| `feat(engine)` | `TemplateImpl._dynamicSuperPagePath` フィールド追加、`PageImpl.resolveExtendsPath()` 切り出し |
| `refactor(builder)` | `DefaultLayoutTemplateBuilder` の Page ミューテート廃止 |
| `fix(engine)` | `RenderUtil` に `dynamicSuperPagePath` フォールバック追加 |
| `fix(engine)` | `requestValidSpecCache` null センチネル残留バグ修正、`createTemplateInstance` で page を事前登録 |
| `test` | `DefaultLayoutTemplateBuilderTest` / `HtmlExtendsTemplateBuilder` / `ExtendsFromTemplateIntegrationTest` 更新 |
| `docs` | `UPGRADING.md` に破壊的変更を記載 |