### PR TITLE
fix(customtag): Rhino 1.9.1 の __parent__ 廃止に対応し simpletest を観点別テストに分解

### DIFF
--- a/src/test/java/org/seasar/mayaa/functional/customtag/CustomTagTest.java
+++ b/src/test/java/org/seasar/mayaa/functional/customtag/CustomTagTest.java
@@ -16,12 +16,18 @@
 package org.seasar.mayaa.functional.customtag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.seasar.mayaa.functional.EngineTestBase;
+import org.seasar.mayaa.impl.management.DiagnosticEventBuffer;
+import org.seasar.mayaa.impl.source.DynamicRegisteredSourceHolder;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 
 public class CustomTagTest extends EngineTestBase {
@@ -91,10 +97,186 @@ public class CustomTagTest extends EngineTestBase {
         execAndVerify(DIR + "target.html", DIR + "expected.html", null);
     }
 
+    @AfterEach
+    public void cleanup() {
+        DynamicRegisteredSourceHolder.unregisterAll();
+    }
+
+    // SimpleTag の基本動作: page スコープから取得した値と simpleName を出力する
     @Test
-    public void simpletest() throws IOException {
-        final String DIR = "/it-case/customtag/simpletest/";
-        execAndVerify(DIR + "target.html", DIR + "expected.html", null);
+    public void simpletest_hello1_customSimpleTag() throws IOException {
+        final String DIR = "/it-case/customtag/simpletest_h1/";
+
+        String targetHtml = """
+                <html><body>
+                <span id="hello1" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">dummy</span>
+                </body></html>
+                """;
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        xmlns:mt="http://mayaa.seasar.org/test/mayaa-test">
+                    <m:beforeRender><![CDATA[
+                        page['SimpleTestTag'] = "hello ";
+                    ]]></m:beforeRender>
+                    <m:echo m:id="hello1">
+                        <mt:simpleTest simpleName="${ 'TestTag' }" />
+                    </m:echo>
+                </m:mayaa>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.mayaa", targetMayaa);
+
+        MockHttpServletResponse response = exec(createRequest(DIR + "target.html"), null);
+        assertTrue(response.getContentAsString().contains("hello TestTag"),
+                "SimpleTestTag should render 'hello TestTag'");
+    }
+
+    /*
+     * [エンジン別動作履歴]
+     * rhino:js:1.7R2          → 成功 (__parent__ は利用可能)
+     * org.mozilla:rhino:1.9.1 → 失敗 __parent__ は Rhino 1.7R3〜R4 で廃止。
+     *                           レンダリング時に例外が発生し DiagnosticEventBuffer にエラーが記録される。
+     */
+    @Test
+    public void simpletest_hello2_pageParentDeprecated() throws IOException {
+        final String DIR = "/it-case/customtag/simpletest_h2/";
+
+        String targetHtml = """
+                <html><body>
+                <span id="hello2">dummy</span>
+                </body></html>
+                """;
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:echo m:id="hello2">
+                        [<m:write value="${ page.__parent__['class']; }"/>]
+                    </m:echo>
+                </m:mayaa>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.mayaa", targetMayaa);
+
+        try {
+            exec(createRequest(DIR + "target.html"), null);
+            fail("Expected RuntimeException due to deprecated __parent__ property");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        List<DiagnosticEventBuffer.Event> events = capture.snapshot();
+        assertTrue(
+                events.stream().anyMatch(e -> e.level() == DiagnosticEventBuffer.Level.ERROR),
+                "DiagnosticEventBuffer should record an error from deprecated page.__parent__");
+    }
+
+    /*
+     * [エンジン別動作履歴]
+     * rhino:js:1.7R2          → 成功 (__parent__ は利用可能)
+     * org.mozilla:rhino:1.9.1 → 失敗 __parent__ は Rhino 1.7R3〜R4 で廃止。
+     *                           レンダリング時に例外が発生し DiagnosticEventBuffer にエラーが記録される。
+     */
+    @Test
+    public void simpletest_hello3_thisParentDeprecated() throws IOException {
+        final String DIR = "/it-case/customtag/simpletest_h3/";
+
+        String targetHtml = """
+                <html><body>
+                <span id="hello3">dummy</span>
+                </body></html>
+                """;
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:echo m:id="hello3">
+                        <m:with>
+                            [<m:write value="${ this.__parent__.__parent__['class']; }"/>]
+                        </m:with>
+                    </m:echo>
+                </m:mayaa>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.mayaa", targetMayaa);
+
+        try {
+            exec(createRequest(DIR + "target.html"), null);
+            fail("Expected RuntimeException due to deprecated __parent__ property");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        List<DiagnosticEventBuffer.Event> events = capture.snapshot();
+        assertTrue(
+                events.stream().anyMatch(e -> e.level() == DiagnosticEventBuffer.Level.ERROR),
+                "DiagnosticEventBuffer should record an error from deprecated this.__parent__");
+    }
+
+    // _ (WalkStandardScope) でカレントノードの class 属性を取得する
+    @Test
+    public void simpletest_hello4_scopeWalk() throws IOException {
+        final String DIR = "/it-case/customtag/simpletest_h4/";
+
+        String targetHtml = """
+                <html><body>
+                <span id="hello4" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">dummy</span>
+                </body></html>
+                """;
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org">
+                    <m:echo m:id="hello4">
+                        <m:with>
+                            [<m:write value="${ _['class']; }"/>]
+                        </m:with>
+                    </m:echo>
+                </m:mayaa>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.mayaa", targetMayaa);
+
+        MockHttpServletResponse response = exec(createRequest(DIR + "target.html"), null);
+        assertTrue(response.getContentAsString().contains("[c&lt;l&amp;a\"s&gt;s]"),
+                "Scope walk _['class'] should return the span's class attribute value");
+    }
+
+    // SimpleTag が JSTL c:if の内側に配置されたとき、親タグとして IfTag を検出できる
+    @Test
+    public void simpletest_hello5_simpleTagInsideJstlIf() throws IOException {
+        final String DIR = "/it-case/customtag/simpletest_h5/";
+
+        String targetHtml = """
+                <html><body>
+                <span id="hello5"><span id="hello6">dummy</span></span>
+                </body></html>
+                """;
+        String targetMayaa = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <m:mayaa xmlns:m="http://mayaa.seasar.org"
+                        xmlns:mt="http://mayaa.seasar.org/test/mayaa-test"
+                        xmlns:c="http://java.sun.com/jstl/core_rt">
+                    <m:beforeRender><![CDATA[
+                        page['SimpleTestTag'] = "hello ";
+                    ]]></m:beforeRender>
+                    <m:echo m:id="hello5">
+                        <c:if test="${ true }"><m:doBody /></c:if>
+                    </m:echo>
+                    <mt:simpleTest m:id="hello6" simpleName="${ 'TestTag' }" />
+                </m:mayaa>
+                """;
+
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.html", targetHtml);
+        DynamicRegisteredSourceHolder.registerContents(DIR + "target.mayaa", targetMayaa);
+
+        MockHttpServletResponse response = exec(createRequest(DIR + "target.html"), null);
+        assertTrue(response.getContentAsString().contains("hello TestTag"),
+                "SimpleTag inside JSTL c:if should render 'hello TestTag'");
+        assertTrue(response.getContentAsString().contains("org.apache.taglibs.standard.tag.rt.core.IfTag"),
+                "SimpleTag should detect IfTag as ancestor via parent chain");
     }
 
     @Test

--- a/src/test/resources/it-case/customtag/simpletest/expected.html
+++ b/src/test/resources/it-case/customtag/simpletest/expected.html
@@ -15,8 +15,8 @@
 
 	<div class="box">
 		<span id="hello1" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">hello TestTagc&lt;l&amp;a"s&gt;s</span><br>
-		<span id="hello2" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">[c&lt;l&amp;a"s&gt;s]</span><br>
-		<span id="hello3" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">[c&lt;l&amp;a"s&gt;s]</span><br>
+		<span id="hello2" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">[NOT SUPPORTED __parent__ REFERENCE]</span><br>
+		<span id="hello3" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">[NOT SUPPORTED __parent__ REFERENCE]</span><br>
 		<span id="hello4" class="c&lt;l&amp;a&quot;s&gt;s" style="display:inline">[c&lt;l&amp;a"s&gt;s]</span><br>
 		<span id="hello5">hello TestTag parent:org.apache.taglibs.standard.tag.rt.core.IfTag</span><br>
 	</div>

--- a/src/test/resources/it-case/customtag/simpletest/target.mayaa
+++ b/src/test/resources/it-case/customtag/simpletest/target.mayaa
@@ -12,13 +12,17 @@
 		<mt:simpleTest simpleName="${ 'TestTag' }" />
 	</m:echo>
 
+	<!-- __parent__ プロパティとして廃止となったためこの参照は非互換となる -->
+	<!-- <m:write value="${ page.__parent__['class']; }"/> -->
 	<m:echo m:id="hello2">
-		[<m:write value="${ page.__parent__['class']; }"/>]
+		[NOT SUPPORTED __parent__ REFERENCE]
 	</m:echo>
 
+	<!-- __parent__ プロパティとして廃止となったためこの参照は非互換となる -->
+	<!-- <m:write value="${ this.__parent__.__parent__['class']; }"/> -->
 	<m:echo m:id="hello3">
 		<m:with>
-			[<m:write value="${ this.__parent__.__parent__['class']; }"/>]
+			[NOT SUPPORTED __parent__ REFERENCE]
 		</m:with>
 	</m:echo>
 


### PR DESCRIPTION
## 概要

Rhino 1.9.1 では `__parent__` プロパティが廃止（1.7R3〜R4 で削除）されているため、
`simpletest` テストケースが失敗していた問題に対応する。

## 変更内容

### `CustomTagTest.java`

`simpletest()` を観点ごとに 5 つのテストメソッドへ分解。
各テストは `DynamicRegisteredSourceHolder` によるインライン定義を使用し、
ページキャッシュ競合を避けるため固有パス (`simpletest_h1`〜`h5`) を使用。

| テストメソッド | 観点 |
|---|---|
| `simpletest_hello1_customSimpleTag` | SimpleTag の基本レンダリング |
| `simpletest_hello2_pageParentDeprecated` | `page.__parent__` 廃止 → 例外 + DiagnosticEventBuffer ERROR |
| `simpletest_hello3_thisParentDeprecated` | `this.__parent__.__parent__` 廃止 → 例外 + DiagnosticEventBuffer ERROR |
| `simpletest_hello4_scopeWalk` | `_['class']` で WalkStandardScope からクラス属性を取得 |
| `simpletest_hello5_simpleTagInsideJstlIf` | SimpleTag が JSTL `c:if` 内で `IfTag` を親として検出できる |

### `simpletest/target.mayaa`

`__parent__` 参照をコメントアウトし、非互換であることをコメントで明示。
代替として固定テキストを配置。

### `simpletest/expected.html`

`target.mayaa` の変更に合わせて期待値を更新。

## 背景

- Rhino 1.9.1 アップグレード（#132）により `__parent__` が利用不可となった
- `__parent__` は Rhino 1.7R3〜R4 で廃止されたプロパティ
- 廃止プロパティへのアクセスは `RuntimeException` を発生させ、`DiagnosticEventBuffer` に `ERROR` レベルのイベントが記録される